### PR TITLE
#581: Update to Scala 2.13.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 // compiler plugins
-addCompilerPlugin("org.scalameta" % "semanticdb-scalac" % "4.4.28" cross CrossVersion.full)
+addCompilerPlugin("org.scalameta" % "semanticdb-scalac" % "4.4.30" cross CrossVersion.full)
 
 name := "scalac-scapegoat-plugin"
 organization := "com.sksamuel.scapegoat"
@@ -22,8 +22,8 @@ developers := List(
   )
 )
 
-scalaVersion := "2.13.6"
-crossScalaVersions := Seq("2.11.12", "2.12.14", "2.12.15", "2.13.5", "2.13.6")
+scalaVersion := "2.13.7"
+crossScalaVersions := Seq("2.11.12", "2.12.14", "2.12.15", "2.13.6", "2.13.7")
 autoScalaLibrary := false
 crossVersion := CrossVersion.full
 crossTarget := {
@@ -39,8 +39,10 @@ val scalac13Options = Seq(
   "-Xlint:inaccessible",
   "-Xlint:infer-any",
   "-Xlint:nullary-unit",
+  "-Xlint:strict-unsealed-patmat",
   "-Yrangepos",
-  "-Ywarn-unused"
+  "-Ywarn-unused",
+  "-Xsource:3"
 )
 val scalac12Options = Seq(
   "-Xlint:adapted-args",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.github.sbt"  % "sbt-ci-release" % "1.5.10")
 addSbtPlugin("com.eed3si9n"  % "sbt-assembly"   % "0.14.10")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"   % "2.4.3")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"   % "0.9.31")
-addSbtPlugin("org.scoverage" % "sbt-scoverage"  % "1.9.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage"  % "1.9.2")
 
 if (System.getProperty("add-scapegoat-plugin") == "true")
   addSbtPlugin(s"com.sksamuel.scapegoat" % "sbt-scapegoat" % "1.1.0")


### PR DESCRIPTION
Updates to Scala 2.13.7 and adds two new compiler flags introduced in the latest versions to make use of strict pattern matching and ease the migration to Scala 3.

It would be nice if you release a new version soon.

Fixes #581.

Closes #582. Closes #583. Closes #584.