### PR TITLE
Find unsafe traversable methods in method chains

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/VariableShadowing.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/VariableShadowing.scala
@@ -42,7 +42,7 @@ class VariableShadowing
                 exit()
               case ValDef(_, TermName(name), _, _) =>
                 if (isDefined(name)) context.warn(tree.pos, self, tree.toString.take(200))
-                contexts.head.append(name.trim)
+                contexts.headOption.foreach(_.append(name.trim))
               case Match(_, cases) =>
                 cases.foreach {
                   case CaseDef(Bind(name, _), _, _) =>

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/DuplicateMapKey.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/DuplicateMapKey.scala
@@ -27,7 +27,10 @@ class DuplicateMapKey
             val keys = trees.foldLeft(List.empty[String])((keys, tree) =>
               tree match {
                 case Apply(TypeApply(Select(Apply(_, args), Arrow | UnicodeArrow), _), _) =>
-                  keys :+ args.head.toString()
+                  args match {
+                    case Nil => keys
+                    case firstArg :: _ => keys :+ firstArg.toString
+                  }
                 case _ => keys
               }
             )

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/UnsafeTraversableMethods.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/UnsafeTraversableMethods.scala
@@ -37,6 +37,7 @@ class UnsafeTraversableMethods
               case Select(left, TermName(method)) =>
                 if (isIterable(left) && unsafeMethods.contains(method))
                   context.warn(tree.pos, self, tree.toString.take(500))
+                else continue(tree)
               case _ => continue(tree)
             }
           }

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/UnsafeTraversableMethodsTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/UnsafeTraversableMethodsTest.scala
@@ -48,11 +48,7 @@ class UnsafeTraversableMethodsTest extends InspectionTest {
 
   "Regression" - {
     "should report warning in method chains" in {
-      val code = """class Test {
-                   val xs = List((1, 1), (1, 2), (2, 3))
-                   val groups = xs.groupBy(_._1)
-                   groups.collect { case (_, groupItems) => groupItems.head._1 }
-                 }""".stripMargin
+      val code = "class Test { List((1, 2)).head._1 }"
 
       compileCodeSnippet(code)
       compiler.scapegoat.feedback.warnings.size shouldBe 1

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/UnsafeTraversableMethodsTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/UnsafeTraversableMethodsTest.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.scapegoat.inspections.collections
 
 import com.sksamuel.scapegoat.InspectionTest
+
 class UnsafeTraversableMethodsTest extends InspectionTest {
 
   override val inspections = Seq(new UnsafeTraversableMethods)
@@ -43,5 +44,18 @@ class UnsafeTraversableMethodsTest extends InspectionTest {
       }
     }
 
+  }
+
+  "Regression" - {
+    "should report warning in method chains" in {
+      val code = """class Test {
+                   val xs = List((1, 1), (1, 2), (2, 3))
+                   val groups = xs.groupBy(_._1)
+                   groups.collect { case (_, groupItems) => groupItems.head._1 }
+                 }""".stripMargin
+
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 1
+    }
   }
 }


### PR DESCRIPTION
Unsafe methods on traversables were not caught if they were followed by another method call because of the missing `else continue(tree)` part.

I've called the test case `Regression` even though this never worked correctly so I'm up for changing that if there's a suggestion for a better name.