### PR TITLE
Revert "Update scalafmt-core to 3.3.1"

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
   
-version = "3.3.1"
+version = "3.2.2"
 maxColumn = 110
 docstrings = JavaDoc
 assumeStandardLibraryStripMargin = true


### PR DESCRIPTION
Reverts scapegoat-scala/scapegoat#608
because of [the failure registered by CI](https://github.com/scapegoat-scala/scapegoat/runs/4749829472?check_suite_focus=true), which boiled down to:
```
   exec /home/runner/bin/jabba install adopt@1.8.0-292
  Installing adopt@1.8.0-292
  Downloading adopt@1.8.0-292 (https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u292b10.tar.gz) 
  Extracting /tmp/jabba-d-851022420 to /home/runner/.jabba/jdk/adopt@1.8.0-292 
  gzip: invalid header 
  0/489
  Error: exec: Downloading adopt@1.8.0-292 (https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u292b10.tar.gz) 
  Extracting /tmp/jabba-d-851022420 to /home/runner/.jabba/jdk/adopt@1.8.0-292 
  gzip: invalid header 
```

Not analyzing it further.