### PR TITLE
Update to Scala 2.13.8

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,12 +1,12 @@
-  
 version = "3.2.2"
+runner.dialect = scala213source3
 maxColumn = 110
-docstrings = JavaDoc
+docstrings.style = Asterisk
 assumeStandardLibraryStripMargin = true
 continuationIndent.defnSite = 2
 align {
   ifWhileOpenParen = false
-  tokens.add = [
+  tokens."+" = [
     "<-",
     {code = "%", owner = "Term.ApplyInfix"},
     {code = "%%", owner = "Term.ApplyInfix"}

--- a/build.sbt
+++ b/build.sbt
@@ -140,11 +140,11 @@ assembly / test := {} // do not run tests during assembly
 Test / publishArtifact := false
 
 // Scalafix
-ThisBuild / scalafixDependencies += "com.nequissimus" %% "sort-imports" % "0.3.1"
-addCommandAlias("fix", "all compile:scalafix test:scalafix; fixImports")
-addCommandAlias("fixImports", "compile:scalafix SortImports; test:scalafix SortImports")
-addCommandAlias("fixCheck", "compile:scalafix --check; test:scalafix --check; fixCheckImports")
-addCommandAlias("fixCheckImports", "compile:scalafix --check SortImports; test:scalafix --check SortImports")
+ThisBuild / scalafixDependencies += "com.nequissimus" %% "sort-imports" % "0.6.1"
+addCommandAlias("fix", "all Compile / scalafix Test / scalafix; fixImports")
+addCommandAlias("fixImports", "Compile / scalafix SortImports; Test / scalafix SortImports")
+addCommandAlias("fixCheck", "Compile / scalafix --check; Test / scalafix --check; fixCheckImports")
+addCommandAlias("fixCheckImports", "Compile / scalafix --check SortImports; Test / scalafix --check SortImports")
 
 // Scalafmt
 ThisBuild / scalafmtOnCompile := sys.env.get("GITHUB_ACTIONS").forall(_.toLowerCase == "false")

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 // compiler plugins
-addCompilerPlugin("org.scalameta" % "semanticdb-scalac" % "4.4.31" cross CrossVersion.full)
+addCompilerPlugin("org.scalameta" % "semanticdb-scalac" % "4.4.32" cross CrossVersion.full)
 
 name := "scalac-scapegoat-plugin"
 organization := "com.sksamuel.scapegoat"
@@ -23,7 +23,7 @@ developers := List(
 )
 
 scalaVersion := "2.13.7"
-crossScalaVersions := Seq("2.11.12", "2.12.14", "2.12.15", "2.13.6", "2.13.7")
+crossScalaVersions := Seq("2.11.12", "2.12.14", "2.12.15", "2.13.7", "2.13.8")
 autoScalaLibrary := false
 crossVersion := CrossVersion.full
 crossTarget := {
@@ -63,7 +63,7 @@ val scalac11Options = Seq(
   "-Ywarn-numeric-widen",
   "-Xmax-classfile-name",
   "254"
-  //"-Ywarn-value-discard"
+  // "-Ywarn-value-discard"
 )
 scalacOptions := {
   val common = Seq(
@@ -109,7 +109,7 @@ libraryDependencies ++= Seq(
     "org.scala-lang"
   ),
   "org.scala-lang" % "scala-compiler" % scalaVersion.value % "test",
-  "org.scalatest" %% "scalatest"      % "3.2.10"            % "test",
+  "org.scalatest" %% "scalatest"      % "3.2.10"           % "test",
   "org.mockito"    % "mockito-all"    % "1.10.19"          % "test",
   "joda-time"      % "joda-time"      % "2.10.13"          % "test",
   "org.joda"       % "joda-convert"   % "2.2.2"            % "test",

--- a/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
@@ -5,7 +5,8 @@ import scala.reflect.internal.util.Position
 import scala.tools.nsc.reporters.Reporter
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class Feedback(
   reporter: Reporter,

--- a/src/main/scala/com/sksamuel/scapegoat/Inspection.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Inspection.scala
@@ -4,7 +4,8 @@ import scala.reflect.internal.util.Position
 import scala.tools.nsc.Global
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 abstract class Inspection(
   val text: String,
@@ -30,8 +31,8 @@ abstract class Inspector(val context: InspectionContext) {
   def postTyperTraverser: context.Traverser
 
   /**
-   * This method is invoked after all phases of the compiler have completed.
-   * This method can be used to clean up inspections; to report errors after all phases are complete.
+   * This method is invoked after all phases of the compiler have completed. This method can be used to clean
+   * up inspections; to report errors after all phases are complete.
    */
   def postInspection(): Unit = ()
 }
@@ -103,7 +104,7 @@ final case class InspectionContext(global: Global, feedback: Feedback) {
         case tri @ Try(_, _, _) if isSuppressed(tri.symbol)      =>
         case ClassDef(_, _, _, Template(parents, _, _))
             if parents.map(_.tpe.typeSymbol.fullName).contains("scala.reflect.api.TypeCreator") =>
-        case _ if analyzer.hasMacroExpansionAttachment(tree) => //skip macros as per http://bit.ly/2uS8BrU
+        case _ if analyzer.hasMacroExpansionAttachment(tree) => // skip macros as per http://bit.ly/2uS8BrU
         case _                                               => inspect(tree)
       }
     }

--- a/src/main/scala/com/sksamuel/scapegoat/Inspections.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Inspections.scala
@@ -19,7 +19,8 @@ import com.sksamuel.scapegoat.inspections.unneccesary._
 import com.sksamuel.scapegoat.inspections.unsafe._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 object Inspections extends App {
 

--- a/src/main/scala/com/sksamuel/scapegoat/Level.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Level.scala
@@ -1,7 +1,8 @@
 package com.sksamuel.scapegoat
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 sealed trait Level
 
@@ -15,12 +16,12 @@ object Levels {
   case object Error extends Level
 
   /**
-   * Warnings are reserved for code that has bad semantics.
-   * This by itself does not necessarily mean the code is buggy, but could mean the developer
-   * made a mistake or does not fully understand the contructs or best practice.
+   * Warnings are reserved for code that has bad semantics. This by itself does not necessarily mean the code
+   * is buggy, but could mean the developer made a mistake or does not fully understand the contructs or best
+   * practice.
    *
-   * An example is an expression as a statement. While this is perfectly legal, it could indicate
-   * that the developer meant to assign the result to or otherwise use it.
+   * An example is an expression as a statement. While this is perfectly legal, it could indicate that the
+   * developer meant to assign the result to or otherwise use it.
    *
    * Another example is a constant if. You can do things like if (true) { } if you want, but since the block
    * will always evaluate, the if statement perhaps indicates a mistake.
@@ -30,12 +31,13 @@ object Levels {
   /**
    * Infos are used for code which is semantically fine, but there exists a more idomatic way of writing it.
    *
-   * An example would be using an if statement to return true or false as the last statement in a block.
-   * Eg,
+   * An example would be using an if statement to return true or false as the last statement in a block. Eg,
    *
+   * {{{
    * def foo = {
    *   if (a) true else false
    * }
+   * }}}
    *
    * Can be re-written as
    *

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/AnyUse.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/AnyUse.scala
@@ -5,7 +5,8 @@ import scala.reflect.internal.Flags
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class AnyUse
     extends Inspection(
@@ -17,7 +18,7 @@ class AnyUse
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/AvoidToMinusOne.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/AvoidToMinusOne.scala
@@ -5,7 +5,8 @@ import scala.runtime.{RichInt, RichLong}
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class AvoidToMinusOne
     extends Inspection(
@@ -17,7 +18,7 @@ class AvoidToMinusOne
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/DoubleNegation.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/DoubleNegation.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class DoubleNegation
     extends Inspection(
@@ -15,7 +16,7 @@ class DoubleNegation
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/EmptyCaseClass.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/EmptyCaseClass.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class EmptyCaseClass
     extends Inspection(
@@ -15,7 +16,7 @@ class EmptyCaseClass
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/LonelySealedTrait.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/LonelySealedTrait.scala
@@ -5,7 +5,8 @@ import scala.collection.mutable
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class LonelySealedTrait
     extends Inspection(
@@ -36,7 +37,7 @@ class LonelySealedTrait
         }
       }
 
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           override def inspect(tree: Tree): Unit = {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/MaxParameters.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/MaxParameters.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class MaxParameters
     extends Inspection(
@@ -16,7 +17,7 @@ class MaxParameters
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._
@@ -24,7 +25,7 @@ class MaxParameters
           private def count(vparamss: List[List[ValDef]]): Int =
             vparamss.foldLeft(0)((a, b) => a + b.size)
 
-          private def countExceeds(vparamss: List[List[ValDef]], limit: Int) =
+          private def countExceeds(vparamss: List[List[ValDef]], limit: Int): Boolean =
             count(vparamss) > limit
 
           override def inspect(tree: Tree): Unit = {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/NoOpOverride.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/NoOpOverride.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class NoOpOverride
     extends Inspection(
@@ -15,7 +16,7 @@ class NoOpOverride
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/PublicFinalizer.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/PublicFinalizer.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class PublicFinalizer
     extends Inspection(
@@ -18,7 +19,7 @@ class PublicFinalizer
 
       import context.global._
 
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           override def inspect(tree: Tree): Unit = {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/TypeShadowing.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/TypeShadowing.scala
@@ -5,7 +5,8 @@ import scala.collection.mutable
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class TypeShadowing
     extends Inspection(
@@ -17,7 +18,7 @@ class TypeShadowing
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/VarClosure.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/VarClosure.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class VarClosure
     extends Inspection(
@@ -18,7 +19,7 @@ class VarClosure
 
       import context.global._
 
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           private def capturesVar(tree: Tree): Unit =

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ArrayEquals.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ArrayEquals.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class ArrayEquals
     extends Inspection(
@@ -16,7 +17,7 @@ class ArrayEquals
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/AvoidSizeEqualsZero.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/AvoidSizeEqualsZero.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class AvoidSizeEqualsZero
     extends Inspection(

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/AvoidSizeNotEqualsZero.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/AvoidSizeNotEqualsZero.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class AvoidSizeNotEqualsZero
     extends Inspection(

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionIndexOnNonIndexedSeq.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionIndexOnNonIndexedSeq.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Josh Rosen
+ * @author
+ *   Josh Rosen
  */
 class CollectionIndexOnNonIndexedSeq
     extends Inspection(
@@ -15,7 +16,7 @@ class CollectionIndexOnNonIndexedSeq
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionNamingConfusion.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionNamingConfusion.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class CollectionNamingConfusion
     extends Inspection(
@@ -16,7 +17,7 @@ class CollectionNamingConfusion
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionNegativeIndex.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionNegativeIndex.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class CollectionNegativeIndex
     extends Inspection(
@@ -16,7 +17,7 @@ class CollectionNegativeIndex
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAny.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAny.scala
@@ -3,8 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
- *         This inspection was inspired by http://p5wscala.wordpress.com/scalaprocessing-gotchas/#t2
+ * @author
+ *   Stephen Samuel This inspection was inspired by http://p5wscala.wordpress.com/scalaprocessing-gotchas/#t2
  */
 class CollectionPromotionToAny
     extends Inspection(
@@ -17,7 +17,7 @@ class CollectionPromotionToAny
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ComparisonToEmptyList.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ComparisonToEmptyList.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class ComparisonToEmptyList
     extends Inspection(
@@ -15,7 +16,7 @@ class ComparisonToEmptyList
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ComparisonToEmptySet.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ComparisonToEmptySet.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class ComparisonToEmptySet
     extends Inspection(
@@ -15,7 +16,7 @@ class ComparisonToEmptySet
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/DuplicateMapKey.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/DuplicateMapKey.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class DuplicateMapKey
     extends Inspection(
@@ -15,7 +16,7 @@ class DuplicateMapKey
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._
@@ -28,7 +29,7 @@ class DuplicateMapKey
               tree match {
                 case Apply(TypeApply(Select(Apply(_, args), Arrow | UnicodeArrow), _), _) =>
                   args match {
-                    case Nil => keys
+                    case Nil           => keys
                     case firstArg :: _ => keys :+ firstArg.toString
                   }
                 case _ => keys

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/DuplicateSetValue.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/DuplicateSetValue.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class DuplicateSetValue
     extends Inspection(
@@ -15,7 +16,7 @@ class DuplicateSetValue
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContains.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContains.scala
@@ -3,9 +3,10 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  *
- *         Inspired by Intellij
+ * Inspired by Intellij
  */
 class ExistsSimplifiableToContains
     extends Inspection(

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContains.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContains.scala
@@ -6,7 +6,7 @@ import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
  * @author
  *   Stephen Samuel
  *
- * Inspired by Intellij
+ * Inspired by IntelliJ
  */
 class ExistsSimplifiableToContains
     extends Inspection(

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotHead.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotHead.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class FilterDotHead
     extends Inspection(
@@ -16,7 +17,7 @@ class FilterDotHead
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotHeadOption.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotHeadOption.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class FilterDotHeadOption
     extends Inspection(
@@ -17,7 +18,7 @@ class FilterDotHeadOption
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotIsEmpty.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotIsEmpty.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class FilterDotIsEmpty
     extends Inspection(
@@ -17,7 +18,7 @@ class FilterDotIsEmpty
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotSize.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotSize.scala
@@ -3,9 +3,10 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  *
- *         Inspired by IntelliJ
+ * Inspired by IntelliJ
  */
 class FilterDotSize
     extends Inspection(
@@ -17,7 +18,7 @@ class FilterDotSize
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/FilterOptionAndGet.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/FilterOptionAndGet.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class FilterOptionAndGet
     extends Inspection(
@@ -15,7 +16,7 @@ class FilterOptionAndGet
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/FindDotIsDefined.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/FindDotIsDefined.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class FindDotIsDefined
     extends Inspection(
@@ -15,7 +16,7 @@ class FindDotIsDefined
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/JavaConversionsUse.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/JavaConversionsUse.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class JavaConversionsUse
     extends Inspection(
@@ -16,7 +17,7 @@ class JavaConversionsUse
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ListAppend.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ListAppend.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class ListAppend
     extends Inspection(
@@ -16,7 +17,7 @@ class ListAppend
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ListSize.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ListSize.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class ListSize
     extends Inspection(
@@ -16,7 +17,7 @@ class ListSize
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElse.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElse.scala
@@ -3,10 +3,11 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Sanjiv Sahayam
+ * @author
+ *   Sanjiv Sahayam
  *
- * Inspired by Intellij inspection that does:
- *   myMap.get(key).getOrElse(defaultValue) –> myMap.getOrElse(key, defaultValue)
+ * Inspired by Intellij inspection that does: myMap.get(key).getOrElse(defaultValue) –> myMap.getOrElse(key,
+ * defaultValue)
  */
 class MapGetAndGetOrElse
     extends Inspection(
@@ -19,7 +20,7 @@ class MapGetAndGetOrElse
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElse.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElse.scala
@@ -6,7 +6,7 @@ import com.sksamuel.scapegoat._
  * @author
  *   Sanjiv Sahayam
  *
- * Inspired by Intellij inspection that does: myMap.get(key).getOrElse(defaultValue) –> myMap.getOrElse(key,
+ * Inspired by IntelliJ inspection that does: myMap.get(key).getOrElse(defaultValue) –> myMap.getOrElse(key,
  * defaultValue)
  */
 class MapGetAndGetOrElse

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/NegationIsEmpty.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/NegationIsEmpty.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class NegationIsEmpty
     extends Inspection(

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/NegationNonEmpty.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/NegationNonEmpty.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class NegationNonEmpty
     extends Inspection(

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/NegativeSeqPad.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/NegativeSeqPad.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class NegativeSeqPad
     extends Inspection(
@@ -15,7 +16,7 @@ class NegativeSeqPad
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PredefIterableIsMutable.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PredefIterableIsMutable.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class PredefIterableIsMutable
     extends Inspection(
@@ -16,7 +17,7 @@ class PredefIterableIsMutable
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PredefSeqIsMutable.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PredefSeqIsMutable.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class PredefSeqIsMutable
     extends Inspection(
@@ -13,11 +14,11 @@ class PredefSeqIsMutable
       explanation = "Predef.Seq aliases scala.collection.mutable.Seq. Did you intend to use an immutable Seq?"
     ) {
 
-  override def isEnabled = !isScala213
+  override def isEnabled: Boolean = !isScala213
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
           import context.global._
 

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PredefTraversableIsMutable.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PredefTraversableIsMutable.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class PredefTraversableIsMutable
     extends Inspection(
@@ -16,7 +17,7 @@ class PredefTraversableIsMutable
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PreferSeqEmpty.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PreferSeqEmpty.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class PreferSeqEmpty
     extends Inspection(
@@ -16,7 +17,7 @@ class PreferSeqEmpty
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PreferSetEmpty.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PreferSetEmpty.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class PreferSetEmpty
     extends Inspection(
@@ -16,7 +17,7 @@ class PreferSetEmpty
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/SwapSortFilter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/SwapSortFilter.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class SwapSortFilter
     extends Inspection(
@@ -16,7 +17,7 @@ class SwapSortFilter
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/UnsafeContains.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/UnsafeContains.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.collections
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class UnsafeContains
     extends Inspection(
@@ -17,7 +18,7 @@ class UnsafeContains
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
           import context.global._
           import treeInfo.Applied
@@ -33,8 +34,8 @@ class UnsafeContains
           private def isCompatibleType(container: Tree, value: Tree, typ: Symbol): Boolean =
             container.tpe baseType typ match {
               case TypeRef(_, _, elem :: Nil) if elem.isInstanceOf[Any] && elem <:< value.tpe => true
-              case TypeRef(_, _, elem :: Nil)                                                 => value.tpe <:< elem
-              case _                                                                          => false
+              case TypeRef(_, _, elem :: Nil) => value.tpe <:< elem
+              case _                          => false
             }
 
           private def isCompatibleType(container: Tree, value: Tree): Boolean =

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/controlflow/WhileTrue.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/controlflow/WhileTrue.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.controlflow
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class WhileTrue
     extends Inspection(
@@ -15,7 +16,7 @@ class WhileTrue
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/empty/EmptyFor.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/empty/EmptyFor.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.empty
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class EmptyFor
     extends Inspection(
@@ -15,7 +16,7 @@ class EmptyFor
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/empty/EmptyIfBlock.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/empty/EmptyIfBlock.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.empty
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class EmptyIfBlock
     extends Inspection(
@@ -15,7 +16,7 @@ class EmptyIfBlock
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/empty/EmptyMethod.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/empty/EmptyMethod.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.empty
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class EmptyMethod
     extends Inspection(
@@ -15,7 +16,7 @@ class EmptyMethod
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._
@@ -23,8 +24,8 @@ class EmptyMethod
           override def inspect(tree: Tree): Unit = {
             tree match {
               // its ok to do empty impl for overridden methods
-              case DefDef(mods, _, _, _, _, _) if mods.isOverride                                   =>
-              case ClassDef(mods, _, _, _) if mods.isTrait                                          => continue(tree)
+              case DefDef(mods, _, _, _, _, _) if mods.isOverride =>
+              case ClassDef(mods, _, _, _) if mods.isTrait        => continue(tree)
               case DefDef(_, _, _, _, _, _) if tree.symbol != null && tree.symbol.enclClass.isTrait =>
               case d @ DefDef(_, _, _, _, _, Literal(Constant(())))
                   if d.symbol != null && d.symbol.isPrivate =>

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/empty/EmptySynchronizedBlock.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/empty/EmptySynchronizedBlock.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.empty
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class EmptySynchronizedBlock
     extends Inspection(
@@ -15,7 +16,7 @@ class EmptySynchronizedBlock
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/empty/EmptyTryBlock.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/empty/EmptyTryBlock.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.empty
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class EmptyTryBlock
     extends Inspection(
@@ -15,7 +16,7 @@ class EmptyTryBlock
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/empty/EmptyWhileBlock.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/empty/EmptyWhileBlock.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.empty
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class EmptyWhileBlock
     extends Inspection(
@@ -15,7 +16,7 @@ class EmptyWhileBlock
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparingFloatingPointTypes.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparingFloatingPointTypes.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.equality
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class ComparingFloatingPointTypes
     extends Inspection(
@@ -16,7 +17,7 @@ class ComparingFloatingPointTypes
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypes.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypes.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.equality
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class ComparingUnrelatedTypes
     extends Inspection(
@@ -16,7 +17,7 @@ class ComparingUnrelatedTypes
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparisonWithSelf.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparisonWithSelf.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.equality
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class ComparisonWithSelf
     extends Inspection(
@@ -15,7 +16,7 @@ class ComparisonWithSelf
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/exception/CatchException.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/exception/CatchException.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.exception
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Marconi Lanna
+ * @author
+ *   Marconi Lanna
  */
 @SuppressWarnings(Array("IncorrectlyNamedExceptions"))
 class CatchException
@@ -17,12 +18,12 @@ class CatchException
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._
 
-          def catchesException(cases: List[CaseDef]) = {
+          def catchesException(cases: List[CaseDef]): Boolean = {
             cases.exists {
               // matches t : Exception
               case CaseDef(Bind(_, Typed(_, tpt)), _, _) if tpt.tpe =:= typeOf[Exception] => true

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/exception/CatchFatal.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/exception/CatchFatal.scala
@@ -5,7 +5,8 @@ import scala.util.control.ControlThrowable
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Marconi Lanna
+ * @author
+ *   Marconi Lanna
  */
 class CatchFatal
     extends Inspection(
@@ -19,12 +20,12 @@ class CatchFatal
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._
 
-          def isFatal(tpe: context.global.Type) = {
+          def isFatal(tpe: context.global.Type): Boolean = {
             tpe =:= typeOf[VirtualMachineError] ||
             tpe =:= typeOf[ThreadDeath] ||
             tpe =:= typeOf[InterruptedException] ||
@@ -32,7 +33,7 @@ class CatchFatal
             tpe =:= typeOf[ControlThrowable]
           }
 
-          def catchesFatal(cases: List[CaseDef]) = {
+          def catchesFatal(cases: List[CaseDef]): Boolean = {
             cases.exists {
               // matches t : FatalException
               case CaseDef(Bind(_, Typed(_, tpt)), _, _) if isFatal(tpt.tpe) => true

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/exception/CatchNpe.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/exception/CatchNpe.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.exception
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class CatchNpe
     extends Inspection(
@@ -15,7 +16,7 @@ class CatchNpe
     ) {
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/exception/CatchThrowable.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/exception/CatchThrowable.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.exception
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class CatchThrowable
     extends Inspection(
@@ -16,12 +17,12 @@ class CatchThrowable
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._
 
-          def catchesThrowable(cases: List[CaseDef]) = {
+          def catchesThrowable(cases: List[CaseDef]): Boolean = {
             cases.exists {
               // matches t : Throwable
               case CaseDef(Bind(_, Typed(_, tpt)), _, _) if tpt.tpe =:= typeOf[Throwable] => true

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/exception/IncorrectlyNamedExceptions.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/exception/IncorrectlyNamedExceptions.scala
@@ -3,9 +3,10 @@ package com.sksamuel.scapegoat.inspections.exception
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  *
- *         Inspired by http://findbugs.sourceforge.net/bugDescriptions.html#NM_CLASS_NOT_EXCEPTION
+ * Inspired by http://findbugs.sourceforge.net/bugDescriptions.html#NM_CLASS_NOT_EXCEPTION
  */
 class IncorrectlyNamedExceptions
     extends Inspection(
@@ -18,7 +19,7 @@ class IncorrectlyNamedExceptions
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/exception/SwallowedException.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/exception/SwallowedException.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.exception
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 @SuppressWarnings(Array("IncorrectlyNamedExceptions"))
 class SwallowedException
@@ -17,7 +18,7 @@ class SwallowedException
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._
@@ -35,7 +36,7 @@ class SwallowedException
             }
           }
 
-          private def checkCatches(defs: List[CaseDef]) =
+          private def checkCatches(defs: List[CaseDef]): Unit =
             defs.foreach {
               case CaseDef(Bind(TermName("ignored") | TermName("ignore"), _), _, _) =>
               case cdef @ CaseDef(_, _, Literal(Constant(()))) if cdef.body.toString == "()" =>

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/exception/UnreachableCatch.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/exception/UnreachableCatch.scala
@@ -5,7 +5,8 @@ import scala.collection.mutable
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class UnreachableCatch
     extends Inspection(
@@ -17,12 +18,12 @@ class UnreachableCatch
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._
 
-          def isUnreachable(cases: List[CaseDef]) = {
+          def isUnreachable(cases: List[CaseDef]): Boolean = {
             val types = mutable.HashSet[Type]()
             def check(tpe: Type, guard: Tree): Boolean = {
               if (types.exists(tpe <:< _))

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/imports/DuplicateImport.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/imports/DuplicateImport.scala
@@ -5,7 +5,8 @@ import scala.collection.mutable
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class DuplicateImport
     extends Inspection(
@@ -20,7 +21,7 @@ class DuplicateImport
 
       private val imports = mutable.HashSet[String]()
 
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/imports/WildcardImport.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/imports/WildcardImport.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.imports
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class WildcardImport
     extends Inspection(
@@ -21,7 +22,7 @@ class WildcardImport
 
       private def isWildcard(trees: List[ImportSelector]): Boolean = trees.exists(_.name == nme.WILDCARD)
 
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           override def inspect(tree: Tree): Unit = {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/inference/BoundedByFinalType.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/inference/BoundedByFinalType.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.inference
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class BoundedByFinalType
     extends Inspection(
@@ -15,7 +16,7 @@ class BoundedByFinalType
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/inference/MethodReturningAny.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/inference/MethodReturningAny.scala
@@ -5,7 +5,8 @@ import scala.reflect.internal.Flags
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class MethodReturningAny
     extends Inspection(
@@ -17,7 +18,7 @@ class MethodReturningAny
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._
@@ -28,7 +29,7 @@ class MethodReturningAny
               case DefDef(mods, _, _, _, _, _) if mods.hasFlag(Flags.SetterFlags) =>
               case DefDef(mods, _, _, _, _, _) if mods.hasFlag(Flags.GetterFlags) =>
               case DefDef(mods, _, _, _, _, _) if mods.hasFlag(Flags.ACCESSOR)    =>
-              /// ignore overridden methods as the parent will receive the warning
+              // ignore overridden methods as the parent will receive the warning
               case DefDef(mods, _, _, _, _, _) if mods.isOverride =>
               case DefDef(_, _, _, _, tpt, _) if tpt.tpe =:= typeOf[Any] || tpt.tpe =:= typeOf[AnyRef] =>
                 context.warn(tree.pos, self, tree.toString.take(300))

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/inference/PointlessTypeBounds.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/inference/PointlessTypeBounds.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.inference
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class PointlessTypeBounds
     extends Inspection(
@@ -15,7 +16,7 @@ class PointlessTypeBounds
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/inference/ProductWithSerializableInferred.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/inference/ProductWithSerializableInferred.scala
@@ -5,7 +5,8 @@ import scala.reflect.internal.Flags
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class ProductWithSerializableInferred
     extends Inspection(
@@ -18,7 +19,7 @@ class ProductWithSerializableInferred
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/matching/PartialFunctionInsteadOfMatch.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/matching/PartialFunctionInsteadOfMatch.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.matching
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class PartialFunctionInsteadOfMatch
     extends Inspection(
@@ -15,7 +16,7 @@ class PartialFunctionInsteadOfMatch
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/matching/RepeatedCaseBody.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/matching/RepeatedCaseBody.scala
@@ -5,7 +5,8 @@ import scala.collection.mutable
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class RepeatedCaseBody
     extends Inspection(
@@ -17,7 +18,7 @@ class RepeatedCaseBody
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/matching/SuspiciousMatchOnClassObject.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/matching/SuspiciousMatchOnClassObject.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.matching
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class SuspiciousMatchOnClassObject
     extends Inspection(
@@ -15,7 +16,7 @@ class SuspiciousMatchOnClassObject
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/math/BigDecimalDoubleConstructor.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/math/BigDecimalDoubleConstructor.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.math
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class BigDecimalDoubleConstructor
     extends Inspection(
@@ -16,7 +17,7 @@ class BigDecimalDoubleConstructor
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/math/BigDecimalScaleWithoutRoundingMode.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/math/BigDecimalScaleWithoutRoundingMode.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.math
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class BigDecimalScaleWithoutRoundingMode
     extends Inspection(
@@ -18,7 +19,7 @@ class BigDecimalScaleWithoutRoundingMode
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/math/BrokenOddness.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/math/BrokenOddness.scala
@@ -3,9 +3,10 @@ package com.sksamuel.scapegoat.inspections.math
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  *
- *         Inspired by http://codenarc.sourceforge.net/codenarc-rules-basic.html#BrokenOddnessCheck
+ * Inspired by http://codenarc.sourceforge.net/codenarc-rules-basic.html#BrokenOddnessCheck
  */
 class BrokenOddness
     extends Inspection(
@@ -18,7 +19,7 @@ class BrokenOddness
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/math/DivideByOne.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/math/DivideByOne.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.math
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class DivideByOne
     extends Inspection(
@@ -15,7 +16,7 @@ class DivideByOne
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/math/ModOne.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/math/ModOne.scala
@@ -3,9 +3,10 @@ package com.sksamuel.scapegoat.inspections.math
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  *
- *         Inspired by http://findbugs.sourceforge.net/bugDescriptions.html#INT_BAD_REM_BY_1
+ * Inspired by http://findbugs.sourceforge.net/bugDescriptions.html#INT_BAD_REM_BY_1
  */
 class ModOne
     extends Inspection(
@@ -17,7 +18,7 @@ class ModOne
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/math/NanComparison.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/math/NanComparison.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.math
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class NanComparison
     extends Inspection(
@@ -15,7 +16,7 @@ class NanComparison
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/math/UseCbrt.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/math/UseCbrt.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.math
 import com.sksamuel.scapegoat._
 
 /**
- * @author Matic Potočnik
+ * @author
+ *   Matic Potočnik
  */
 class UseCbrt
     extends Inspection(
@@ -15,7 +16,7 @@ class UseCbrt
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/math/UseExpM1.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/math/UseExpM1.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.math
 import com.sksamuel.scapegoat._
 
 /**
- * @author Matic Potočnik
+ * @author
+ *   Matic Potočnik
  */
 class UseExpM1
     extends Inspection(
@@ -15,7 +16,7 @@ class UseExpM1
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/math/ZeroNumerator.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/math/ZeroNumerator.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.math
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class ZeroNumerator
     extends Inspection(
@@ -15,7 +16,7 @@ class ZeroNumerator
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/naming/ClassNames.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/naming/ClassNames.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.naming
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class ClassNames
     extends Inspection(
@@ -15,7 +16,7 @@ class ClassNames
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/naming/MethodNames.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/naming/MethodNames.scala
@@ -5,7 +5,8 @@ import scala.reflect.internal.Flags
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class MethodNames
     extends Inspection(
@@ -18,7 +19,7 @@ class MethodNames
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/naming/ObjectNames.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/naming/ObjectNames.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.naming
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class ObjectNames
     extends Inspection(
@@ -15,7 +16,7 @@ class ObjectNames
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/nulls/NullAssignment.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/nulls/NullAssignment.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.nulls
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class NullAssignment
     extends Inspection(
@@ -15,7 +16,7 @@ class NullAssignment
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/nulls/NullParameter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/nulls/NullParameter.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.nulls
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class NullParameter
     extends Inspection(
@@ -15,12 +16,12 @@ class NullParameter
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._
 
-          def containsNull(trees: List[Tree]) =
+          def containsNull(trees: List[Tree]): Boolean =
             trees exists {
               case Literal(Constant(null)) => true
               case _                       => false

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/option/EitherGet.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/option/EitherGet.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.option
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class EitherGet
     extends Inspection(
@@ -16,7 +17,7 @@ class EitherGet
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/option/ImpossibleOptionSizeCondition.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/option/ImpossibleOptionSizeCondition.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.option
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class ImpossibleOptionSizeCondition
     extends Inspection(
@@ -15,7 +16,7 @@ class ImpossibleOptionSizeCondition
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/option/OptionGet.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/option/OptionGet.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.option
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class OptionGet
     extends Inspection(
@@ -16,7 +17,7 @@ class OptionGet
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/option/OptionSize.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/option/OptionSize.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.option
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class OptionSize
     extends Inspection(
@@ -16,7 +17,7 @@ class OptionSize
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/string/ArraysInFormat.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/string/ArraysInFormat.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.string
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class ArraysInFormat
     extends Inspection(
@@ -15,12 +16,12 @@ class ArraysInFormat
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._
 
-          private def containsArrayType(trees: List[Tree]) = trees.exists(isArray)
+          private def containsArrayType(trees: List[Tree]): Boolean = trees.exists(isArray)
 
           override def inspect(tree: Tree): Unit = {
             tree match {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/string/ArraysToString.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/string/ArraysToString.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.string
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class ArraysToString
     extends Inspection(
@@ -15,7 +16,7 @@ class ArraysToString
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/string/EmptyInterpolatedString.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/string/EmptyInterpolatedString.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.string
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class EmptyInterpolatedString
     extends Inspection(
@@ -16,7 +17,7 @@ class EmptyInterpolatedString
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/string/IllegalFormatString.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/string/IllegalFormatString.scala
@@ -5,7 +5,8 @@ import java.util.IllegalFormatException
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class IllegalFormatString
     extends Inspection(
@@ -21,7 +22,7 @@ class IllegalFormatString
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/string/IncorrectNumberOfArgsToFormat.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/string/IncorrectNumberOfArgsToFormat.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.string
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class IncorrectNumberOfArgsToFormat
     extends Inspection(
@@ -20,12 +21,12 @@ class IncorrectNumberOfArgsToFormat
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._
 
-          private def doesNotTakeArguments(formatSpecifier: String) =
+          private def doesNotTakeArguments(formatSpecifier: String): Boolean =
             formatSpecifier == "%%" || formatSpecifier == "%n"
 
           override def inspect(tree: Tree): Unit = {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/string/InvalidRegex.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/string/InvalidRegex.scala
@@ -5,7 +5,8 @@ import java.util.regex.PatternSyntaxException
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class InvalidRegex
     extends Inspection(
@@ -18,7 +19,7 @@ class InvalidRegex
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/string/StripMarginOnRegex.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/string/StripMarginOnRegex.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.string
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class StripMarginOnRegex
     extends Inspection(
@@ -15,7 +16,7 @@ class StripMarginOnRegex
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/string/SubstringZero.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/string/SubstringZero.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.string
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class SubstringZero
     extends Inspection(
@@ -15,7 +16,7 @@ class SubstringZero
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/string/UnsafeStringContains.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/string/UnsafeStringContains.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.string
 import com.sksamuel.scapegoat._
 
 /**
- * @author Zack Grannan
+ * @author
+ *   Zack Grannan
  */
 class UnsafeStringContains
     extends Inspection(
@@ -16,7 +17,7 @@ class UnsafeStringContains
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/style/AvoidOperatorOverload.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/style/AvoidOperatorOverload.scala
@@ -5,9 +5,10 @@ import scala.reflect.internal.Flags
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  *
- *         http://docs.scala-lang.org/style/naming-conventions.html#symbolic-method-names
+ * http://docs.scala-lang.org/style/naming-conventions.html#symbolic-method-names
  */
 class AvoidOperatorOverload
     extends Inspection(
@@ -20,7 +21,7 @@ class AvoidOperatorOverload
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/style/ParameterlessMethodReturnsUnit.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/style/ParameterlessMethodReturnsUnit.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.style
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class ParameterlessMethodReturnsUnit
     extends Inspection(
@@ -16,7 +17,7 @@ class ParameterlessMethodReturnsUnit
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/style/SimplifyBooleanExpression.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/style/SimplifyBooleanExpression.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.style
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class SimplifyBooleanExpression
     extends Inspection(
@@ -14,7 +15,7 @@ class SimplifyBooleanExpression
     ) {
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/ConstantIf.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/ConstantIf.scala
@@ -3,9 +3,10 @@ package com.sksamuel.scapegoat.inspections.unneccesary
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  *
- *         Checks for if statements where the condition evaluates to a constant true or a constant false.
+ * Checks for if statements where the condition evaluates to a constant true or a constant false.
  */
 class ConstantIf
     extends Inspection(
@@ -18,7 +19,7 @@ class ConstantIf
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/RedundantFinalizer.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/RedundantFinalizer.scala
@@ -3,9 +3,10 @@ package com.sksamuel.scapegoat.inspections.unneccesary
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  *
- *         Inspired by http://findbugs.sourceforge.net/bugDescriptions.html#FI_USELESS
+ * Inspired by http://findbugs.sourceforge.net/bugDescriptions.html#FI_USELESS
  */
 class RedundantFinalizer
     extends Inspection(
@@ -18,7 +19,7 @@ class RedundantFinalizer
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/UnnecessaryConversion.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/UnnecessaryConversion.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.unneccesary
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class UnnecessaryConversion
     extends Inspection(
@@ -16,7 +17,7 @@ class UnnecessaryConversion
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/UnnecessaryIf.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/UnnecessaryIf.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.unneccesary
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class UnnecessaryIf
     extends Inspection(
@@ -16,7 +17,7 @@ class UnnecessaryIf
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/UnnecessaryReturnUse.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/UnnecessaryReturnUse.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.unneccesary
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class UnnecessaryReturnUse
     extends Inspection(
@@ -16,7 +17,7 @@ class UnnecessaryReturnUse
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/UnusedMethodParameter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/UnusedMethodParameter.scala
@@ -5,7 +5,8 @@ import scala.reflect.internal.Flags
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class UnusedMethodParameter
     extends Inspection(
@@ -17,7 +18,7 @@ class UnusedMethodParameter
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._
@@ -49,11 +50,10 @@ class UnusedMethodParameter
           /**
            * For constructor params, some params become vals / fields of the class:
            *   1. all params in the first argument list for case classes
-           *   2. all params marked "val"
+           *   1. all params marked "val"
            *
-           * In both cases, by the time we see the tree, a "def x = this.x" method
-           * will have been added by the compiler, so "usesField" will notice and
-           * not mark the param as unused.
+           * In both cases, by the time we see the tree, a "def x = this.x" method will have been added by the
+           * compiler, so "usesField" will notice and not mark the param as unused.
            */
           private def checkConstructor(
             vparamss: List[List[ValDef]],

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/VarCouldBeVal.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/VarCouldBeVal.scala
@@ -5,7 +5,8 @@ import scala.collection.mutable
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class VarCouldBeVal
     extends Inspection(
@@ -17,7 +18,7 @@ class VarCouldBeVal
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/unsafe/FinalizerWithoutSuper.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/unsafe/FinalizerWithoutSuper.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.unsafe
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class FinalizerWithoutSuper
     extends Inspection(
@@ -16,7 +17,7 @@ class FinalizerWithoutSuper
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/unsafe/IsInstanceOf.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/unsafe/IsInstanceOf.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.unsafe
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class IsInstanceOf
     extends Inspection(
@@ -16,7 +17,7 @@ class IsInstanceOf
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/unsafe/TryGet.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/unsafe/TryGet.scala
@@ -3,7 +3,8 @@ package com.sksamuel.scapegoat.inspections.unsafe
 import com.sksamuel.scapegoat._
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 class TryGet
     extends Inspection(
@@ -16,7 +17,7 @@ class TryGet
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {
-      override def postTyperTraverser =
+      override def postTyperTraverser: context.Traverser =
         new context.Traverser {
 
           import context.global._

--- a/src/main/scala/com/sksamuel/scapegoat/io/HtmlReportWriter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/io/HtmlReportWriter.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.scapegoat.io
 
 import scala.xml.{Elem, Unparsed}
+
 import com.sksamuel.scapegoat.{Feedback, Levels}
 
 /**

--- a/src/main/scala/com/sksamuel/scapegoat/io/HtmlReportWriter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/io/HtmlReportWriter.scala
@@ -1,11 +1,11 @@
 package com.sksamuel.scapegoat.io
 
-import scala.xml.Unparsed
-
+import scala.xml.{Elem, Unparsed}
 import com.sksamuel.scapegoat.{Feedback, Levels}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 object HtmlReportWriter extends ReportWriter {
 
@@ -64,7 +64,7 @@ object HtmlReportWriter extends ReportWriter {
       |
     """.stripMargin
 
-  private def header =
+  private def header: Elem =
     <head>
       <title>Scapegoat Inspection Reporter</title>{
       Unparsed(
@@ -83,7 +83,7 @@ object HtmlReportWriter extends ReportWriter {
        </style>
     </head>
 
-  private def body(reporter: Feedback) =
+  private def body(reporter: Feedback): Elem =
     <body>
       <h1>Scapegoat Inspections</h1>
       <h3>
@@ -96,7 +96,7 @@ object HtmlReportWriter extends ReportWriter {
       </h3>{warnings(reporter)}
     </body>
 
-  private def warnings(reporter: Feedback) = {
+  private def warnings(reporter: Feedback): Seq[Elem] = {
     reporter.warningsWithMinimalLevel.map { warning =>
       val source = warning.sourceFileNormalized + ":" + warning.line
       <div class="warning">
@@ -129,7 +129,7 @@ object HtmlReportWriter extends ReportWriter {
     }
   }
 
-  private def toHTML(reporter: Feedback) =
+  private def toHTML(reporter: Feedback): Elem =
     <html>
       {header}{body(reporter)}
     </html>

--- a/src/main/scala/com/sksamuel/scapegoat/io/IOUtils.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/io/IOUtils.scala
@@ -5,7 +5,8 @@ import java.io.File
 import com.sksamuel.scapegoat.Feedback
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 object IOUtils {
   def writeHTMLReport(targetDir: File, reporter: Feedback): File =

--- a/src/main/scala/com/sksamuel/scapegoat/io/XmlReportWriter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/io/XmlReportWriter.scala
@@ -1,11 +1,11 @@
 package com.sksamuel.scapegoat.io
 
-import scala.xml.Node
-
+import scala.xml.{Elem, Node}
 import com.sksamuel.scapegoat.{Feedback, Warning}
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 object XmlReportWriter extends ReportWriter {
 
@@ -19,7 +19,7 @@ object XmlReportWriter extends ReportWriter {
     </scapegoat>
   }
 
-  private def warning2xml(warning: Warning) =
+  private def warning2xml(warning: Warning): Elem =
     <warning line={warning.line.toString} text={warning.text} snippet={warning.snippet.orNull} explanation={
       warning.explanation
     } level={warning.level.toString} file={warning.sourceFileNormalized} inspection={warning.inspection}/>

--- a/src/main/scala/com/sksamuel/scapegoat/io/XmlReportWriter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/io/XmlReportWriter.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.scapegoat.io
 
 import scala.xml.{Elem, Node}
+
 import com.sksamuel.scapegoat.{Feedback, Warning}
 
 /**

--- a/src/test/scala/com/sksamuel/scapegoat/PluginRunner.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/PluginRunner.scala
@@ -4,6 +4,7 @@ import java.io.{File, FileNotFoundException}
 import java.net.URL
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+
 import scala.tools.nsc.Settings
 import scala.tools.nsc.reporters.ConsoleReporter
 

--- a/src/test/scala/com/sksamuel/scapegoat/PluginRunner.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/PluginRunner.scala
@@ -4,19 +4,20 @@ import java.io.{File, FileNotFoundException}
 import java.net.URL
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-
+import scala.tools.nsc.Settings
 import scala.tools.nsc.reporters.ConsoleReporter
 
 /**
- * @author Stephen Samuel
+ * @author
+ *   Stephen Samuel
  */
 trait PluginRunner {
 
-  val scalaVersion = util.Properties.versionNumberString
+  val scalaVersion: String = util.Properties.versionNumberString
 
-  val classPath = getScalaJars.map(_.getAbsolutePath) :+ sbtCompileDir.getAbsolutePath
+  val classPath: List[String] = getScalaJars.map(_.getAbsolutePath) :+ sbtCompileDir.getAbsolutePath
 
-  val settings = {
+  val settings: Settings = {
     val s = new scala.tools.nsc.Settings
     for (_ <- Option(System.getProperty("printphases"))) {
       s.Xprint.value = List("all")


### PR DESCRIPTION
- Updates to Scala 2.13.8
- Stops compiling for 2.13.6
- Updates to SemanticDB 4.4.32 (required for Scala 2.13.8)
- Added required ScalaFmt dialect (required for ScalaFmt 3.x, using `scala213source3` for now, we could also use `fileOverride` for version specific dialect: https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects)
- Use `Asterisk` docstrings style which supersedes `JavaDoc` style
- Re-format on compile (thus so many files)
- Update Scalafix to use slash-style SBT syntax (deprecated in SBT 1.5.x)

Closes #611.
Fixes #614.