### PR TITLE
Change severity in Checkstyle output to lowercase

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/io/ScalastyleReportWriter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/io/ScalastyleReportWriter.scala
@@ -24,7 +24,7 @@ object ScalastyleReportWriter extends ReportWriter {
   }
 
   private def warningToXml(warning: Warning) =
-    <error line={warning.line.toString} message={warning.text} severity={warning.level.toString} source={
+    <error line={warning.line.toString} message={warning.text} severity={warning.level.toString.toLowerCase()} source={
       warning.inspection
     } snippet={warning.snippet.orNull} explanation={warning.explanation}></error>
 


### PR DESCRIPTION
Hi! 👋 

I'm currently adding this GitHub Action to our pipeline to display and annotate the code with the results from the scapegoat-run. Unfortunately, everything is just an "Annotation", because the GH Action expects the `severity` in the xml to be lowercase.

The DTD unfortunately doesn't define the `severity` attribute (https://checkstyle.org/dtds/configuration_1_3.dtd), but 

* the `google_checks` use `warning` as default: https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml#L22
* the puppycrawl-implementation explicitly changes to lowercase: https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/api/SeverityLevel.java#L56
* the `sun_checks` use `error` as default: https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/sun_checks.xml#L42
* the docs list all four levels in lowercase: https://checkstyle.sourceforge.io/property_types.html#SeverityLevel

So I think this change would make the output "more compliant" and make parsing the xml a but easier 😊 