### PR TITLE
Fix Scalafmt config & format

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -19,10 +19,12 @@ rewrite {
   rules = [PreferCurlyFors, RedundantBraces, RedundantParens, SortImports]
   redundantBraces.maxLines = 1
 }
-indentOperator.preset = spray
+indentOperator {
+  preset = spray
+  topLevelOnly = true
+}
 project {
   git = true
   excludeFilters = ["target"]
 }
 spaces.inImportCurlyBraces = false
-unindentTopLevelOperators = true

--- a/src/main/scala/com/sksamuel/scapegoat/Configuration.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Configuration.scala
@@ -64,9 +64,7 @@ object Configuration {
             case _ =>
               throw new IllegalArgumentException(
                 s"Malformed argument to 'overrideLevels': '$nameLevel'. " +
-                "Expecting 'name=level' where 'name' is the simple name of " +
-                "an inspection and 'level' is the simple name of a " +
-                "com.sksamuel.scapegoat.Level constant, e.g. 'Warning'."
+                  "Expecting 'name=level' where 'name' is the simple name of an inspection and 'level' is the simple name of a com.sksamuel.scapegoat.Level constant, e.g. 'Warning'."
               )
           }
         }.toMap

--- a/src/main/scala/com/sksamuel/scapegoat/Inspection.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Inspection.scala
@@ -86,8 +86,7 @@ final case class InspectionContext(global: Global, feedback: Feedback) {
       an.tree.tpe =:= SuppressWarnings || an.tree.tpe.erasure.toString == "com.sksamuel.scapegoat.Safe"
 
     private def isSuppressed(symbol: Symbol) =
-      symbol != null &&
-      symbol.annotations.exists(an => isSkipAnnotation(an) && isThisDisabled(an))
+      symbol != null && symbol.annotations.exists(an => isSkipAnnotation(an) && isThisDisabled(an))
 
     protected def continue(tree: Tree): Unit = super.traverse(tree)
 

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/AvoidToMinusOne.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/AvoidToMinusOne.scala
@@ -30,9 +30,9 @@ class AvoidToMinusOne
 
           private def isIntegral(tree: Tree): Boolean =
             tree.tpe <:< IntTpe ||
-            tree.tpe <:< LongTpe ||
-            tree.tpe <:< typeOf[RichInt] ||
-            tree.tpe <:< typeOf[RichLong]
+              tree.tpe <:< LongTpe ||
+              tree.tpe <:< typeOf[RichInt] ||
+              tree.tpe <:< typeOf[RichLong]
 
           override def inspect(tree: Tree): Unit = {
             tree match {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/RedundantFinalModifierOnMethod.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/RedundantFinalModifierOnMethod.scala
@@ -31,10 +31,7 @@ class RedundantFinalModifierOnMethod
               case DefDef(_, nme.CONSTRUCTOR, _, _, _, _)                      =>
               case DefDef(mods, _, _, _, _, _)
                   if mods.isFinal &&
-                    (tree.symbol.enclClass.isFinal ||
-                    tree.symbol.enclClass.isCase ||
-                    tree.symbol.enclClass.isModuleOrModuleClass ||
-                    tree.symbol.enclClass.isPackageObjectOrClass) =>
+                    (tree.symbol.enclClass.isFinal || tree.symbol.enclClass.isCase || tree.symbol.enclClass.isModuleOrModuleClass || tree.symbol.enclClass.isPackageObjectOrClass) =>
                 context.warn(tree.pos, self)
               case _ => continue(tree)
             }

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/RedundantFinalModifierOnVar.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/RedundantFinalModifierOnVar.scala
@@ -22,10 +22,7 @@ class RedundantFinalModifierOnVar
             tree match {
               case ValDef(mods, _, _, _)
                   if mods.isFinal && mods.isMutable &&
-                    (tree.symbol.enclClass.isFinal ||
-                    tree.symbol.enclClass.isCase ||
-                    tree.symbol.enclClass.isModuleOrModuleClass ||
-                    tree.symbol.enclClass.isPackageObjectOrClass) =>
+                    (tree.symbol.enclClass.isFinal || tree.symbol.enclClass.isCase || tree.symbol.enclClass.isModuleOrModuleClass || tree.symbol.enclClass.isPackageObjectOrClass) =>
                 context.warn(tree.pos, self)
               case _ => continue(tree)
             }

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionNamingConfusion.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionNamingConfusion.scala
@@ -23,11 +23,9 @@ class CollectionNamingConfusion
           import context.global._
 
           private def isNamedSet(name: String): Boolean =
-            name.trim == "set" || name.trim.endsWith("Set") ||
-            name.matches(".*Set[A-Z].*")
+            name.trim == "set" || name.trim.endsWith("Set") || name.matches(".*Set[A-Z].*")
           private def isNamedList(name: String): Boolean =
-            name.trim == "list" || name.trim.endsWith("List") ||
-            name.matches(".*List[A-Z].*")
+            name.trim == "list" || name.trim.endsWith("List") || name.matches(".*List[A-Z].*")
 
           override def inspect(tree: Tree): Unit = {
             tree match {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotHeadOption.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotHeadOption.scala
@@ -12,8 +12,7 @@ class FilterDotHeadOption
       defaultLevel = Levels.Info,
       description = "Checks for use of filter().headOption.",
       explanation =
-        "`filter()` scans the entire collection, which is unnecessary if you only want to get the first element that " +
-        "satisfies the predicate - `filter().headOption` can be replaced with `find()` to potentially avoid scanning the entire collection."
+        "`filter()` scans the entire collection, which is unnecessary if you only want to get the first element that satisfies the predicate - `filter().headOption` can be replaced with `find()` to potentially avoid scanning the entire collection."
     ) {
 
   def inspector(context: InspectionContext): Inspector =

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotIsEmpty.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotIsEmpty.scala
@@ -12,8 +12,7 @@ class FilterDotIsEmpty
       defaultLevel = Levels.Info,
       description = "Checks for use of filter().isEmpty.",
       explanation =
-        "`filter()` scans the entire collection, which can potentially be avoided if the element exists in the " +
-        "collection - `filter().isEmpty` can be replaced with `!exists()`."
+        "`filter()` scans the entire collection, which can potentially be avoided if the element exists in the collection - `filter().isEmpty` can be replaced with `!exists()`."
     ) {
 
   def inspector(context: InspectionContext): Inspector =

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ReverseFunc.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ReverseFunc.scala
@@ -8,8 +8,7 @@ class ReverseFunc
       defaultLevel = Levels.Info,
       description = "Checks for use of reverse followed by head/headOption/iterator/map.",
       explanation =
-        "`reverse` followed by `head`, `headOption`, `iterator`, or `map` can be replaced, respectively, with " +
-        "`last`, `lastOption`, `reverseIterator`, or `reverseMap`."
+        "`reverse` followed by `head`, `headOption`, `iterator`, or `map` can be replaced, respectively, with `last`, `lastOption`, `reverseIterator`, or `reverseMap`."
     ) {
 
   object FuncReplace {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/UnsafeContains.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/UnsafeContains.scala
@@ -12,8 +12,7 @@ class UnsafeContains
       defaultLevel = Levels.Error,
       description = "Checks `Seq.contains()` and `Option.contains()` for unrelated types.",
       explanation =
-        "`contains()` accepts arguments af any type, which means you might be checking if your collection " +
-        "contains an element of an unrelated type."
+        "`contains()` accepts arguments af any type, which means you might be checking if your collection contains an element of an unrelated type."
     ) {
 
   def inspector(context: InspectionContext): Inspector =

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/math/BigDecimalScaleWithoutRoundingMode.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/math/BigDecimalScaleWithoutRoundingMode.scala
@@ -13,8 +13,7 @@ class BigDecimalScaleWithoutRoundingMode
       description =
         "Checks for use of `setScale()` on a BigDecimal without setting the rounding mode can throw an exception.",
       explanation =
-        "When using `setScale()` on a BigDecimal without setting the rounding mode, this can throw an exception " +
-        "if rounding is required. Did you mean to call `setScale(s, RoundingMode.XYZ)`?"
+        "When using `setScale()` on a BigDecimal without setting the rounding mode, this can throw an exception if rounding is required. Did you mean to call `setScale(s, RoundingMode.XYZ)`?"
     ) {
 
   def inspector(context: InspectionContext): Inspector =

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/math/UseCbrt.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/math/UseCbrt.scala
@@ -24,9 +24,7 @@ class UseCbrt
           override def inspect(tree: Tree): Unit = {
             tree match {
               case Apply(Select(pack, TermName("pow")), List(_, Literal(Constant(third: Double))))
-                  if (pack.symbol.fullNameString == "scala.math.package"
-                  || pack.symbol.fullNameString == "java.lang.Math"
-                  || pack.symbol.fullNameString == "java.lang.StrictMath")
+                  if (pack.symbol.fullNameString == "scala.math.package" || pack.symbol.fullNameString == "java.lang.Math" || pack.symbol.fullNameString == "java.lang.StrictMath")
                     && third >= 0.3333332
                     && third <= 0.3333334 =>
                 context.warn(tree.pos, self)

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/math/UseLog10.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/math/UseLog10.scala
@@ -20,9 +20,7 @@ class UseLog10
           override def inspect(tree: Tree): Unit = {
 
             def isMathPackage(pack: String) =
-              pack == "scala.math.package" ||
-              pack == "java.lang.Math" ||
-              pack == "java.lang.StrictMath"
+              pack == "scala.math.package" || pack == "java.lang.Math" || pack == "java.lang.StrictMath"
 
             tree match {
               case Apply(

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/math/UseLog1P.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/math/UseLog1P.scala
@@ -18,9 +18,7 @@ class UseLog1P
           import context.global._
 
           def isMathPackage(pack: String): Boolean =
-            pack == "scala.math.package" ||
-            pack == "java.lang.Math" ||
-            pack == "java.lang.StrictMath"
+            pack == "scala.math.package" || pack == "java.lang.Math" || pack == "java.lang.StrictMath"
 
           override def inspect(tree: Tree): Unit = {
             tree match {

--- a/src/main/scala/com/sksamuel/scapegoat/io/ScalastyleReportWriter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/io/ScalastyleReportWriter.scala
@@ -1,7 +1,6 @@
 package com.sksamuel.scapegoat.io
 
-import scala.xml.Node
-
+import scala.xml.{Elem, Node}
 import com.sksamuel.scapegoat.{Feedback, Warning}
 
 object ScalastyleReportWriter extends ReportWriter {
@@ -23,8 +22,10 @@ object ScalastyleReportWriter extends ReportWriter {
     </file>
   }
 
-  private def warningToXml(warning: Warning) =
-    <error line={warning.line.toString} message={warning.text} severity={warning.level.toString.toLowerCase()} source={
+  private def warningToXml(warning: Warning): Elem =
+    <error line={warning.line.toString} message={warning.text} severity={
+      warning.level.toString.toLowerCase()
+    } source={
       warning.inspection
     } snippet={warning.snippet.orNull} explanation={warning.explanation}></error>
 

--- a/src/main/scala/com/sksamuel/scapegoat/io/ScalastyleReportWriter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/io/ScalastyleReportWriter.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.scapegoat.io
 
 import scala.xml.{Elem, Node}
+
 import com.sksamuel.scapegoat.{Feedback, Warning}
 
 object ScalastyleReportWriter extends ReportWriter {


### PR DESCRIPTION
`unindentTopLevelOperators` was removed in https://github.com/scalameta/scalafmt/commit/9402b81a4de3ba876303ca3cdff0fcac1f88d2c2.
`indentOperator.topLevelOnly` should be used instead.
Updated the config with that change and reformatted all files.