### PR TITLE
Fix: Inform about Boolean Parameters not for case class initializer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ developers := List(
   )
 )
 
-scalaVersion := "2.13.7"
+scalaVersion := "2.13.8"
 crossScalaVersions := Seq("2.11.12", "2.12.14", "2.12.15", "2.13.7", "2.13.8")
 autoScalaLibrary := false
 crossVersion := CrossVersion.full

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/BooleanParameter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/BooleanParameter.scala
@@ -34,7 +34,8 @@ class BooleanParameter
           case DefDef(mods, _, _, _, _, _) if mods.hasFlag(Flags.ACCESSOR)    =>
           // ignore overridden methods as the parent will receive the warning
           case DefDef(mods, _, _, _, _, _) if mods.isOverride =>
-          case DefDef(_, _, _, vparamss, _, _) if hasBooleanParameter(vparamss) =>
+          case DefDef(_, name, _, vparamss, _, _)
+              if hasBooleanParameter(vparamss) && name != TermName("<init>") =>
             context.warn(tree.pos, self, tree.toString.take(300))
           case _ => continue(tree)
         }

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/BooleanParameterTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/BooleanParameterTest.scala
@@ -16,6 +16,13 @@ class BooleanParameterTest extends InspectionTest {
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 1
       }
+
+      "not for case classes using Boolean parameter" in {
+        val code = """final case class Test(bool: Boolean)""".stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
     }
   }
 }


### PR DESCRIPTION
I made an error in my last PR because I didn't know that for any `case class` with a Boolean parameter the compiler actually creates a method called `<init>` in the automatically generated companion object that has the constructor parameters. In that method's parameters there's obviously also the Boolean parameter. We don't want to show an info for `case class`es, though.

This filters for these methods and adds a negative test as well.

Could we get this merged and released quickly?