### PR TITLE
Support Scala 2.12.16

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11, 17]
+        java: [8, 11]
         scala:
           - 2.11.12
           - 2.12.15

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,14 +8,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11]
+        java: [8, 11, 17]
         scala:
           - 2.11.12
-          - 2.12.13
-          - 2.12.14
-          - 2.13.5
+          - 2.12.15
+          - 2.12.16
           - 2.13.6
           - 2.13.7
+          - 2.13.8
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v10

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Scapegoat
 
 [![Codecov](https://img.shields.io/codecov/c/github/sksamuel/scapegoat)](https://codecov.io/gh/sksamuel/scapegoat)
 [<img src="https://img.shields.io/maven-central/v/com.sksamuel.scapegoat/scalac-scapegoat-plugin_2.11.12.svg?label=latest%20release%20for%202.11.12"/>](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22scalac-scapegoat-plugin_2.11.12%22)
-[<img src="https://img.shields.io/maven-central/v/com.sksamuel.scapegoat/scalac-scapegoat-plugin_2.12.15.svg?label=latest%20release%20for%202.12.15"/>](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22scalac-scapegoat-plugin_2.12.15%22)
+[<img src="https://img.shields.io/maven-central/v/com.sksamuel.scapegoat/scalac-scapegoat-plugin_2.12.16.svg?label=latest%20release%20for%202.12.16"/>](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22scalac-scapegoat-plugin_2.12.16%22)
 [<img src="https://img.shields.io/maven-central/v/com.sksamuel.scapegoat/scalac-scapegoat-plugin_2.13.8.svg?label=latest%20release%20for%202.13.8"/>](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22scalac-scapegoat-plugin_2.13.8%22)
 [![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-blue.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org)
 

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ developers := List(
 )
 
 scalaVersion := "2.13.8"
-crossScalaVersions := Seq("2.11.12", "2.12.14", "2.12.15", "2.13.7", "2.13.8")
+crossScalaVersions := Seq("2.11.12", "2.12.15", "2.12.16", "2.13.7", "2.13.8")
 autoScalaLibrary := false
 crossVersion := CrossVersion.full
 crossTarget := {

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 // compiler plugins
-addCompilerPlugin("org.scalameta" % "semanticdb-scalac" % "4.5.8" cross CrossVersion.full)
+addCompilerPlugin("org.scalameta" % "semanticdb-scalac" % "4.5.9" cross CrossVersion.full)
 
 name := "scalac-scapegoat-plugin"
 organization := "com.sksamuel.scapegoat"

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypesTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypesTest.scala
@@ -1,11 +1,11 @@
 package com.sksamuel.scapegoat.inspections.equality
 
-import com.sksamuel.scapegoat.InspectionTest
+import com.sksamuel.scapegoat.{Inspection, InspectionTest}
 
 /** @author Stephen Samuel */
 class ComparingUnrelatedTypesTest extends InspectionTest {
 
-  override val inspections = Seq(new ComparingUnrelatedTypes)
+  override val inspections: Seq[Inspection] = Seq(new ComparingUnrelatedTypes)
 
   private def verifyNoWarnings(code: String): Unit = {
     compileCodeSnippet(code)
@@ -56,10 +56,10 @@ class ComparingUnrelatedTypesTest extends InspectionTest {
       }
       "for char" - {
         "compared to char-sized long literal" in {
-          verifyNoWarnings("""object A { val c = 'a'; val c = l == 97L }""")
+          verifyNoWarnings("""object A { val c = 'a'; val l = c == 97L }""")
         }
         "compared to char-sized int literal" in {
-          verifyNoWarnings("""object A { val c = 'a'; val c = l == 97 }""")
+          verifyNoWarnings("""object A { val c = 'a'; val l = c == 97 }""")
         }
       }
       "for short" - {

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/matching/PartialFunctionInsteadOfMatchTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/matching/PartialFunctionInsteadOfMatchTest.scala
@@ -1,11 +1,11 @@
 package com.sksamuel.scapegoat.inspections.matching
 
-import com.sksamuel.scapegoat.InspectionTest
+import com.sksamuel.scapegoat.{Inspection, InspectionTest}
 
 /** @author Stephen Samuel */
 class PartialFunctionInsteadOfMatchTest extends InspectionTest {
 
-  override val inspections = Seq(new PartialFunctionInsteadOfMatch)
+  override val inspections: Seq[Inspection] = Seq(new PartialFunctionInsteadOfMatch)
 
   "when using match instead of partial function" - {
     "should report warning" in {
@@ -83,10 +83,6 @@ class PartialFunctionInsteadOfMatchTest extends InspectionTest {
                      future onComplete {
                        case _ =>
                      }
-                     future onSuccess {
-                      case _ =>
-                     }
-
 
                     } """.stripMargin
 


### PR DESCRIPTION
It was released last month. I wanted to update a cross-built library but Scapegoat failed. This adds the relevant support.