### PR TITLE
Shade all of scala-collection-compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,9 @@ Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oDTF")
 // include the scala xml and compat modules into the final jar, shaded
 assembly / assemblyShadeRules := Seq(
   ShadeRule.rename("scala.xml.**" -> "scapegoat.xml.@1").inAll,
-  ShadeRule.rename("scala.collection.compat.**" -> "scapegoat.compat.@1").inAll
+  ShadeRule.rename("scala.collection.compat.**" -> "scapegoat.compat.@1").inAll,
+  // scala-collection-compat has classes outside of the previous shade path, move them as well.
+  ShadeRule.rename("scala.util.control.compat.**" -> "scapegoat.util.@1").inAll
 )
 Compile / packageBin := crossTarget.value / (assembly / assemblyJarName).value
 makePom := makePom.dependsOn(assembly).value


### PR DESCRIPTION
When running projects from IDE, intellij (somewhat) incorrectly puts scapegoat on the classpath as well, causing issues with some of the scala-collection-compat classes due to binary mismatches.
The scala-collection-compat jar has a few classes outside of `scala.collection.compat.**` (like scala.jdk.CollectionConverters$). With this fix all of the classes are shaded into scapegoat.x packages removing the potential clash with the regular scala-collection-compat

Note: The version currently used in scapegoat only has some util.compat classes (seem the old versions had more), I've narrowed the scope down to only shade that path