### PR TITLE
PredefTraversableIsMutable & PredefIterableIsMutable don't apply on Scala 2.13

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PredefIterableIsMutable.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PredefIterableIsMutable.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
+import com.sksamuel.scapegoat.{isScala213, Inspection, InspectionContext, Inspector, Levels}
 
 /**
  * @author
@@ -14,6 +14,8 @@ class PredefIterableIsMutable
       explanation =
         "Iterable aliases scala.collection.mutable.Iterable. Did you intend to use an immutable Iterable?"
     ) {
+
+  override def isEnabled: Boolean = !isScala213
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PredefTraversableIsMutable.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PredefTraversableIsMutable.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
+import com.sksamuel.scapegoat.{isScala213, Inspection, InspectionContext, Inspector, Levels}
 
 /**
  * @author
@@ -14,6 +14,8 @@ class PredefTraversableIsMutable
       explanation =
         "Traversable aliases scala.collection.mutable.Traversable. Did you intend to use an immutable Traversable?"
     ) {
+
+  override def isEnabled: Boolean = !isScala213
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PredefIterableIsMutableTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PredefIterableIsMutableTest.scala
@@ -1,25 +1,29 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.InspectionTest
+import com.sksamuel.scapegoat.{isScala213, Inspection, InspectionTest}
 
 /** @author Stephen Samuel */
 class PredefIterableIsMutableTest extends InspectionTest {
 
-  override val inspections = Seq(new PredefIterableIsMutable)
+  override val inspections: Seq[Inspection] = Seq(new PredefIterableIsMutable)
 
   "PredefIterableIsMutable" - {
     "should report warning" - {
       "for Iterable apply" in {
         val code = """object Test { val a = Iterable("sammy") }""".stripMargin
+        val expectedWarnings = if (isScala213) 0 else 1
         compileCodeSnippet(code)
-        compiler.scapegoat.feedback.warnings.size shouldBe 1
+        compiler.scapegoat.feedback.warnings.size shouldBe expectedWarnings
       }
+
       "for declaring Iterable as return type" in {
         val code = """object Test { def foo : Iterable[String] = ??? }""".stripMargin
+        val expectedWarnings = if (isScala213) 0 else 1
         compileCodeSnippet(code)
-        compiler.scapegoat.feedback.warnings.size shouldBe 1
+        compiler.scapegoat.feedback.warnings.size shouldBe expectedWarnings
       }
     }
+
     "should not report warning" - {
       "for scala.collection.mutable usage" in {
         val code = """import scala.collection.mutable.Iterable
@@ -27,18 +31,21 @@ class PredefIterableIsMutableTest extends InspectionTest {
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
+
       "for scala.collection.immutable usage" in {
         val code = """import scala.collection.immutable.Iterable
                      |object Test { val a = Iterable("sammy") }""".stripMargin
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
+
       "for scala.collection.mutable defs" in {
         val code = """import scala.collection.mutable.Iterable
                      |object Test { def foo : Iterable[String] = ??? }""".stripMargin
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
+
       "for scala.collection.immutable defs" in {
         val code = """import scala.collection.immutable.Iterable
                      |object Test { def foo : Iterable[String] = ??? }""".stripMargin


### PR DESCRIPTION
Fixes #289.
Fixes #294.