### PR TITLE
Address deprecations in FeedbackTest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,25 +31,18 @@ crossTarget := {
   target.value / s"scala-${scalaVersion.value}"
 }
 
-// https://github.com/sksamuel/scapegoat/issues/298
-ThisBuild / useCoursier := false
-
 val scalac13Options = Seq(
-  "-Xlint:adapted-args",
   "-Xlint:inaccessible",
   "-Xlint:infer-any",
-  "-Xlint:nullary-unit",
   "-Xlint:strict-unsealed-patmat",
   "-Yrangepos",
   "-Ywarn-unused",
   "-Xsource:3"
 )
 val scalac12Options = Seq(
-  "-Xlint:adapted-args",
   "-Ywarn-inaccessible",
   "-Ywarn-infer-any",
   "-Xlint:nullary-override",
-  "-Xlint:nullary-unit",
   "-Xmax-classfile-name",
   "254"
 )
@@ -61,15 +54,13 @@ scalacOptions := {
     "-feature",
     "-encoding",
     "utf8",
-    "-Xlint"
+    "-Xlint",
+    "-Xlint:adapted-args",
+    "-Xlint:nullary-unit"
   )
   common ++ (scalaBinaryVersion.value match {
     case "2.12" => scalac12Options
-    case "2.13" =>
-      scalac13Options ++ (scalaVersion.value.split('.') match {
-        case Array(_, _, patch) if Set("0", "1", "2")(patch) => Seq("-Xlint:nullary-override")
-        case _                                               => Seq.empty[String]
-      })
+    case "2.13" => scalac13Options
   })
 }
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,9 @@ crossTarget := {
   target.value / s"scala-${scalaVersion.value}"
 }
 
+// https://github.com/sksamuel/scapegoat/issues/298
+ThisBuild / useCoursier := false
+
 val scalac13Options = Seq(
   "-Xlint:inaccessible",
   "-Xlint:infer-any",

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PredefIterableIsMutable.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PredefIterableIsMutable.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
+import com.sksamuel.scapegoat.{isScala213, Inspection, InspectionContext, Inspector, Levels}
 
 /**
  * @author
@@ -14,6 +14,8 @@ class PredefIterableIsMutable
       explanation =
         "Iterable aliases scala.collection.mutable.Iterable. Did you intend to use an immutable Iterable?"
     ) {
+
+  override def isEnabled: Boolean = !isScala213
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PredefTraversableIsMutable.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PredefTraversableIsMutable.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
+import com.sksamuel.scapegoat.{isScala213, Inspection, InspectionContext, Inspector, Levels}
 
 /**
  * @author
@@ -14,6 +14,8 @@ class PredefTraversableIsMutable
       explanation =
         "Traversable aliases scala.collection.mutable.Traversable. Did you intend to use an immutable Traversable?"
     ) {
+
+  override def isEnabled: Boolean = !isScala213
 
   def inspector(context: InspectionContext): Inspector =
     new Inspector(context) {

--- a/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
@@ -2,10 +2,11 @@ package com.sksamuel.scapegoat
 
 import scala.reflect.internal.util.NoPosition
 import scala.tools.nsc.reporters.StoreReporter
-
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{OneInstancePerTest, PrivateMethodTester}
+
+import scala.tools.nsc.Settings
 
 /** @author Stephen Samuel */
 class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest with PrivateMethodTester {
@@ -31,17 +32,18 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
           "This is description.",
           "This is explanation."
         )
-        val reporter = new StoreReporter
+        val reporter = new StoreReporter(new Settings())
         val feedback = new Feedback(reporter, testConfiguration(consoleOutput = true, defaultSourcePrefix))
         feedback.warn(position, inspection)
         reporter.infos should contain(
-          reporter.Info(
+          StoreReporter.Info(
             position,
             "[scapegoat] [DummyInspection] My default is Error\n  This is explanation.",
             reporter.ERROR
           )
         )
       }
+
       "for warning" in {
         val inspection = new DummyInspection(
           "My default is Warning",
@@ -49,17 +51,18 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
           "This is description.",
           "This is explanation."
         )
-        val reporter = new StoreReporter
+        val reporter = new StoreReporter(new Settings())
         val feedback = new Feedback(reporter, testConfiguration(consoleOutput = true, defaultSourcePrefix))
         feedback.warn(position, inspection)
         reporter.infos should contain(
-          reporter.Info(
+          StoreReporter.Info(
             position,
             "[scapegoat] [DummyInspection] My default is Warning\n  This is explanation.",
             reporter.WARNING
           )
         )
       }
+
       "for info" in {
         val inspection = new DummyInspection(
           "My default is Info",
@@ -67,11 +70,11 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
           "This is description.",
           "This is explanation."
         )
-        val reporter = new StoreReporter
+        val reporter = new StoreReporter(new Settings())
         val feedback = new Feedback(reporter, testConfiguration(consoleOutput = true, defaultSourcePrefix))
         feedback.warn(position, inspection)
         reporter.infos should contain(
-          reporter.Info(
+          StoreReporter.Info(
             position,
             "[scapegoat] [DummyInspection] My default is Info\n  This is explanation.",
             reporter.INFO
@@ -79,10 +82,11 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
         )
       }
     }
+
     "should use proper paths" - {
       "for `src/main/scala`" in {
         val normalizeSourceFile = PrivateMethod[String](Symbol("normalizeSourceFile"))
-        val reporter = new StoreReporter
+        val reporter = new StoreReporter(new Settings())
         val feedback = new Feedback(reporter, testConfiguration(consoleOutput = true, defaultSourcePrefix))
         val source = "src/main/scala/com/sksamuel/scapegoat/Test.scala"
         val result = feedback invokePrivate normalizeSourceFile(source)
@@ -91,7 +95,7 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
 
       "for `app`" in {
         val normalizeSourceFile = PrivateMethod[String](Symbol("normalizeSourceFile"))
-        val reporter = new StoreReporter
+        val reporter = new StoreReporter(new Settings())
         val feedback = new Feedback(reporter, testConfiguration(consoleOutput = true, "app/"))
         val source = "app/com/sksamuel/scapegoat/Test.scala"
         val result = feedback invokePrivate normalizeSourceFile(source)
@@ -100,13 +104,14 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
 
       "should add trailing / to the sourcePrefix automatically" in {
         val normalizeSourceFile = PrivateMethod[String](Symbol("normalizeSourceFile"))
-        val reporter = new StoreReporter
+        val reporter = new StoreReporter(new Settings())
         val feedback = new Feedback(reporter, testConfiguration(consoleOutput = true, "app/custom"))
         val source = "app/custom/com/sksamuel/scapegoat/Test.scala"
         val result = feedback invokePrivate normalizeSourceFile(source)
         result should ===("com.sksamuel.scapegoat.Test.scala")
       }
     }
+
     "should use minimal warning level in reports" - {
       "for `info`" in {
         val inspectionError = new DummyInspection(
@@ -128,7 +133,7 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
           "This is explanation."
         )
         val inspections = Seq(inspectionError, inspectionWarning, inspectionInfo)
-        val reporter = new StoreReporter
+        val reporter = new StoreReporter(new Settings())
         val feedback =
           new Feedback(reporter, testConfiguration(consoleOutput = true, defaultSourcePrefix, Levels.Info))
         inspections.foreach(inspection => feedback.warn(position, inspection))
@@ -155,7 +160,7 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
           "This is explanation."
         )
         val inspections = Seq(inspectionError, inspectionWarning, inspectionInfo)
-        val reporter = new StoreReporter
+        val reporter = new StoreReporter(new Settings())
         val feedback =
           new Feedback(
             reporter,
@@ -187,7 +192,7 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
           "This is explanation."
         )
         val inspections = Seq(inspectionError, inspectionWarning, inspectionInfo)
-        val reporter = new StoreReporter
+        val reporter = new StoreReporter(new Settings())
         val feedback =
           new Feedback(reporter, testConfiguration(consoleOutput = false, defaultSourcePrefix, Levels.Error))
         inspections.foreach(inspection => feedback.warn(position, inspection))

--- a/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
@@ -1,12 +1,12 @@
 package com.sksamuel.scapegoat
 
 import scala.reflect.internal.util.NoPosition
+import scala.tools.nsc.Settings
 import scala.tools.nsc.reporters.StoreReporter
+
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{OneInstancePerTest, PrivateMethodTester}
-
-import scala.tools.nsc.Settings
 
 /** @author Stephen Samuel */
 class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest with PrivateMethodTester {

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/BooleanParameterTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/BooleanParameterTest.scala
@@ -10,8 +10,8 @@ class BooleanParameterTest extends InspectionTest {
     "should report info" - {
       "for methods using Boolean parameter" in {
         val code = """class Test {
-                       def foo(bool: Boolean) = 4
-                    } """.stripMargin
+                        def foo(bool: Boolean) = 4
+                      }""".stripMargin
 
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 1

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PredefIterableIsMutableTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PredefIterableIsMutableTest.scala
@@ -1,25 +1,29 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.InspectionTest
+import com.sksamuel.scapegoat.{isScala213, Inspection, InspectionTest}
 
 /** @author Stephen Samuel */
 class PredefIterableIsMutableTest extends InspectionTest {
 
-  override val inspections = Seq(new PredefIterableIsMutable)
+  override val inspections: Seq[Inspection] = Seq(new PredefIterableIsMutable)
 
   "PredefIterableIsMutable" - {
     "should report warning" - {
       "for Iterable apply" in {
         val code = """object Test { val a = Iterable("sammy") }""".stripMargin
+        val expectedWarnings = if (isScala213) 0 else 1
         compileCodeSnippet(code)
-        compiler.scapegoat.feedback.warnings.size shouldBe 1
+        compiler.scapegoat.feedback.warnings.size shouldBe expectedWarnings
       }
+
       "for declaring Iterable as return type" in {
         val code = """object Test { def foo : Iterable[String] = ??? }""".stripMargin
+        val expectedWarnings = if (isScala213) 0 else 1
         compileCodeSnippet(code)
-        compiler.scapegoat.feedback.warnings.size shouldBe 1
+        compiler.scapegoat.feedback.warnings.size shouldBe expectedWarnings
       }
     }
+
     "should not report warning" - {
       "for scala.collection.mutable usage" in {
         val code = """import scala.collection.mutable.Iterable
@@ -27,18 +31,21 @@ class PredefIterableIsMutableTest extends InspectionTest {
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
+
       "for scala.collection.immutable usage" in {
         val code = """import scala.collection.immutable.Iterable
                      |object Test { val a = Iterable("sammy") }""".stripMargin
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
+
       "for scala.collection.mutable defs" in {
         val code = """import scala.collection.mutable.Iterable
                      |object Test { def foo : Iterable[String] = ??? }""".stripMargin
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
+
       "for scala.collection.immutable defs" in {
         val code = """import scala.collection.immutable.Iterable
                      |object Test { def foo : Iterable[String] = ??? }""".stripMargin


### PR DESCRIPTION
These deprecations came into effect with Scala 2.12. Since we dropped support for Scala 2.11, I did the changes.

Also removing some specific scalac options for not any longer supported patch versions of Scala 2.13.