### PR TITLE
Reduce false positives on comparing unrelated types

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypes.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypes.scala
@@ -53,6 +53,11 @@ class ComparingUnrelatedTypes
                   if integralLiteralFitsInType(lit, value.tpe) =>
               case Apply(Select(lit @ Literal(_), TermName("$eq$eq" | "$bang$eq")), List(value))
                   if integralLiteralFitsInType(lit, value.tpe) =>
+              // Comparing number types like BigDecimal to integer types causes boxing to promote
+              // the integer to Number to do the comparison.
+              case Apply(Select(lhs, TermName("$eq$eq" | "$bang$eq")), List(rhs))
+                  if (lhs.tpe <:< typeOf[Number] && rhs.tpe.typeSymbol.isNumericValueClass) ||
+                    (rhs.tpe <:< typeOf[Number] && lhs.tpe.typeSymbol.isNumericValueClass) =>
               // -- End special cases ------------------------------------------------------------------
 
               case Apply(Select(lhs, op @ TermName("$eq$eq" | "$bang$eq")), List(rhs)) =>

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypesTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypesTest.scala
@@ -73,6 +73,14 @@ class ComparingUnrelatedTypesTest extends InspectionTest {
       "for float" - {
         "compared to zero" in verifyNoWarnings("""object A { val f = 100f; val b = f == 0 }""")
       }
+
+      "for numbers types comparing to number literals" - {
+        "number left hand side" in verifyNoWarnings("""object A { val a = BigDecimal(5); val b = a == 0 } """)
+        "number right hand side" in verifyNoWarnings(
+          """object A { val a = BigDecimal(5); val b = 0 != a } """
+        )
+      }
+
       "for same enum values" in {
         val code = """object Main {
                         def main(args: Array[String]): Unit = {


### PR DESCRIPTION
```
scala> BigDecimal(5) == 0
val res0: Boolean = false

scala> BigDecimal(0) == 0
val res1: Boolean = true
```

Scapegoat still seem to get the Literal instead of the boxed variants which I observed in bytecode after diagnosing a violation in my codebases. This special clause will handle these cases.