### PR TITLE
Allow empty if statements if they're captured by a function

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/empty/EmptyIfBlock.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/empty/EmptyIfBlock.scala
@@ -23,6 +23,8 @@ class EmptyIfBlock
 
           override def inspect(tree: Tree): Unit = {
             tree match {
+              // Function directly contains if, an empty block would generate Unit (or Any) output type
+              case Function(_, If(_, Literal(Constant(())), _)) => // skip tree
               case If(_, Literal(Constant(())), _) =>
                 context.warn(tree.pos, self, tree.toString.take(500))
               case _ => continue(tree)

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptyIfBlockTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptyIfBlockTest.scala
@@ -10,7 +10,8 @@ class EmptyIfBlockTest extends InspectionTest {
   "empty if block" - {
     "should report warning" in {
 
-      val code = """object Test {
+      val code =
+        """object Test {
 
                       if (true) {
                       }
@@ -27,6 +28,27 @@ class EmptyIfBlockTest extends InspectionTest {
 
       compileCodeSnippet(code)
       compiler.scapegoat.feedback.warnings.size shouldBe 2
+    }
+
+    "should not report warning" - {
+      "the if-block is the return value" in {
+        val code =
+          """
+            |import scala.concurrent.Future
+            |import scala.concurrent.ExecutionContext.Implicits.global
+            |object Test {
+            |  Future("test").map(value => {
+            |   if (value.contains("foo")) {
+            |     ()
+            |   } else {
+            |     throw new IllegalStateException("Bar!")
+            |   }
+            |  })
+            |}""".stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #229 

While I don't fully agree with the presented sample, I do agree with the spirit. So a more generic solution is to ignore the If blocks entirely if they're the body of a Function (ie, they affect the return types).