### PR TITLE
fix: Angle brackets no longer cause malformed html reports

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/io/HtmlReportWriter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/io/HtmlReportWriter.scala
@@ -2,7 +2,7 @@ package com.sksamuel.scapegoat.io
 
 import scala.xml.{Elem, Unparsed, XML}
 
-import com.sksamuel.scapegoat.{Feedback, Levels}
+import com.sksamuel.scapegoat.{Feedback, Levels, Warning}
 
 /**
  * @author
@@ -100,11 +100,11 @@ object HtmlReportWriter extends ReportWriter {
         {reporter.warnings(Levels.Warning).size.toString}
         Infos
         {reporter.warnings(Levels.Info).size.toString}
-      </h3>{warnings(reporter)}
+      </h3>{warnings(reporter.warningsWithMinimalLevel)}
     </body>
 
-  private def warnings(reporter: Feedback): Seq[Elem] = {
-    reporter.warningsWithMinimalLevel.map { warning =>
+  private[io] def warnings(warnings: Seq[Warning]): Seq[Elem] = {
+    warnings.map { warning =>
       val source = warning.sourceFileNormalized + ":" + warning.line
       <div class="warning">
           <div class="source">
@@ -123,7 +123,7 @@ object HtmlReportWriter extends ReportWriter {
           </span>
           </div>
           <div>
-            {decorateCode(warning.explanation)}
+            {decorateCode(warning.explanation.replace("<", "&lt;").replace(">", "&gt;"))}
           </div>{
         warning.snippet match {
           case None =>

--- a/src/test/scala/com/sksamuel/scapegoat/io/HtmlReportWriterTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/io/HtmlReportWriterTest.scala
@@ -1,0 +1,44 @@
+package com.sksamuel.scapegoat.io
+
+import com.sksamuel.scapegoat.{Levels, Warning}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class HtmlReportWriterTest extends AnyFreeSpec with Matchers {
+
+  "HtmlReportWriter" - {
+    "should escape angle brackets" in {
+      val warnings = Seq(
+        Warning(
+          "Pointless type bounds",
+          13,
+          Levels.Error,
+          "/home/johnnei/git/scapegoat/src/main/scala/com/sksamuel/File.scala",
+          "com.sksamuel.File.scala",
+          None,
+          explanation = "Finds type bounds of the form `A <: Any` or `A >: Nothing`.",
+          inspection = "com.sksamuel.scapegoat.inspections.inference.PointlessTypeBounds"
+        )
+      )
+
+      val escapedReport = Seq(
+        <div class="warning">
+          <div class="source">
+            com.sksamuel.File.scala:13
+          </div>
+          <div class="title">
+            <span class="label label-danger">Error</span>&nbsp;<span>Pointless type bounds</span>&nbsp; <span class="inspection">
+            com.sksamuel.scapegoat.inspections.inference.PointlessTypeBounds
+          </span>
+          </div>
+          <div>
+            <span>Finds type bounds of the form <code>A &lt;: Any</code> or <code>A &gt;: Nothing</code>.</span>
+          </div>
+        </div>
+      )
+
+      val report = HtmlReportWriter.warnings(warnings)
+      report.toString() shouldEqual escapedReport.toString()
+    }
+  }
+}


### PR DESCRIPTION
PointlessTypeBound inspection has angle brackets in the explanation. The HTML report tries to pretty format the code and parse it back to XML element which has dangling angle brackets causing failure.

Fixes https://github.com/scapegoat-scala/sbt-scapegoat/issues/175