### PR TITLE
refactor: Decouple scala version checks from exact version list

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/UnnecessaryConversion.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/UnnecessaryConversion.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.scapegoat.inspections.unneccesary
 
-import com.sksamuel.scapegoat.{isScala21312, Inspection, InspectionContext, Inspector, Levels}
+import com.sksamuel.scapegoat.{isScala21312OrLater, Inspection, InspectionContext, Inspector, Levels}
 
 /**
  * @author
@@ -15,7 +15,7 @@ class UnnecessaryConversion
         "Calling e.g. toString on a String or toList on a List is completely unnecessary and it's an equivalent to identity."
     ) {
 
-  override def isEnabled: Boolean = !isScala21312
+  override def isEnabled: Boolean = !isScala21312OrLater
 
   def inspector(ctx: InspectionContext): Inspector = new Inspector(ctx) {
     override def postTyperTraverser: context.Traverser = new context.Traverser {

--- a/src/main/scala/com/sksamuel/scapegoat/package.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/package.scala
@@ -1,9 +1,19 @@
 package com.sksamuel
 
-package object scapegoat {
-  val scalaVersion: String = util.Properties.versionNumberString
-  private val shortScalaVersion = scalaVersion.split('.').dropRight(1).mkString(".")
+import scala.util.Try
 
-  val isScala213: Boolean = shortScalaVersion == "2.13"
-  val isScala21312: Boolean = scalaVersion == "2.13.12"
+package object scapegoat {
+  private val scalaVersion: String = util.Properties.versionNumberString
+  private val (major, minor, patch) = extractComponents(scalaVersion)
+
+  val isScala213: Boolean = major == 2 && minor == 13
+  val isScala21312OrLater: Boolean = isScala213 && patch >= 12
+
+  private[scapegoat] def extractComponents(version: String) = {
+    def parseInt(s: String) = Try(s.toInt).getOrElse(0)
+    version.split('.').toList.map(parseInt) match {
+      case List(major, minor, patch) => (major, minor, patch)
+      case _                         => (1, 0, 0)
+    }
+  }
 }

--- a/src/test/scala/com/sksamuel/scapegoat/ScapegoatTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/ScapegoatTest.scala
@@ -1,0 +1,14 @@
+package com.sksamuel.scapegoat
+
+import com.sksamuel.scapegoat._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class ScapegoatTest extends AnyFreeSpec with Matchers {
+
+  "ScalaVersionPattern" - {
+    "shoud extract components" in {
+      extractComponents("2.13.12") shouldBe (2, 13, 12)
+    }
+  }
+}

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnnecessaryConversionTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnnecessaryConversionTest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.scapegoat.inspections.unnecessary
 
 import com.sksamuel.scapegoat.inspections.unneccesary.UnnecessaryConversion
-import com.sksamuel.scapegoat.{isScala21312, Inspection, InspectionTest}
+import com.sksamuel.scapegoat.{isScala21312OrLater, Inspection, InspectionTest}
 
 /** @author Stephen Samuel */
 class UnnecessaryConversionTest extends InspectionTest {
@@ -17,7 +17,7 @@ class UnnecessaryConversionTest extends InspectionTest {
                      |}""".stripMargin
 
         compileCodeSnippet(code)
-        val expectedWarnings = if (isScala21312) 0 else 1
+        val expectedWarnings = if (isScala21312OrLater) 0 else 1
         compiler.scapegoat.feedback.warnings.size shouldBe expectedWarnings
       }
 
@@ -28,7 +28,7 @@ class UnnecessaryConversionTest extends InspectionTest {
                      |}""".stripMargin
 
         compileCodeSnippet(code)
-        val expectedWarnings = if (isScala21312) 0 else 1
+        val expectedWarnings = if (isScala21312OrLater) 0 else 1
         compiler.scapegoat.feedback.warnings.size shouldBe expectedWarnings
       }
 
@@ -39,7 +39,7 @@ class UnnecessaryConversionTest extends InspectionTest {
                      |}""".stripMargin
 
         compileCodeSnippet(code)
-        val expectedWarnings = if (isScala21312) 0 else 2
+        val expectedWarnings = if (isScala21312OrLater) 0 else 2
         compiler.scapegoat.feedback.warnings.size shouldBe expectedWarnings
       }
 
@@ -50,7 +50,7 @@ class UnnecessaryConversionTest extends InspectionTest {
                      |}""".stripMargin
 
         compileCodeSnippet(code)
-        val expectedWarnings = if (isScala21312) 0 else 1
+        val expectedWarnings = if (isScala21312OrLater) 0 else 1
         compiler.scapegoat.feedback.warnings.size shouldBe expectedWarnings
       }
 
@@ -61,7 +61,7 @@ class UnnecessaryConversionTest extends InspectionTest {
                      |}""".stripMargin
 
         compileCodeSnippet(code)
-        val expectedWarnings = if (isScala21312) 0 else 1
+        val expectedWarnings = if (isScala21312OrLater) 0 else 1
         compiler.scapegoat.feedback.warnings.size shouldBe expectedWarnings
       }
 
@@ -72,7 +72,7 @@ class UnnecessaryConversionTest extends InspectionTest {
                      |}""".stripMargin
 
         compileCodeSnippet(code)
-        val expectedWarnings = if (isScala21312) 0 else 1
+        val expectedWarnings = if (isScala21312OrLater) 0 else 1
         compiler.scapegoat.feedback.warnings.size shouldBe expectedWarnings
       }
 
@@ -83,7 +83,7 @@ class UnnecessaryConversionTest extends InspectionTest {
                      |}""".stripMargin
 
         compileCodeSnippet(code)
-        val expectedWarnings = if (isScala21312) 0 else 1
+        val expectedWarnings = if (isScala21312OrLater) 0 else 1
         compiler.scapegoat.feedback.warnings.size shouldBe expectedWarnings
       }
 
@@ -94,7 +94,7 @@ class UnnecessaryConversionTest extends InspectionTest {
                      |}""".stripMargin
 
         compileCodeSnippet(code)
-        val expectedWarnings = if (isScala21312) 0 else 1
+        val expectedWarnings = if (isScala21312OrLater) 0 else 1
         compiler.scapegoat.feedback.warnings.size shouldBe expectedWarnings
       }
     }


### PR DESCRIPTION
Follow up on https://github.com/scapegoat-scala/scapegoat/pull/789#discussion_r1322663458 to allow minimum version checks rather than exact version matching.
This flow allows for each component to fail parsing which may quite defensive.

Triggered by a basic version update got a gotcha because we match on exact patterns: https://github.com/scapegoat-scala/scapegoat/pull/824