### PR TITLE
Migrate from setup-scala to setup-java action

### DIFF
--- a/.github/workflows/master-codecov.yml
+++ b/.github/workflows/master-codecov.yml
@@ -8,9 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: olafurpg/setup-scala@v14
+      - uses: actions/setup-java@v4
         with:
-          java-version: adopt@1.11
+          distribution: adopt
+          java-version: 11
       - uses: actions/cache@v4
         with:
           path: ~/.ivy2/cache

--- a/.github/workflows/master-release.yml
+++ b/.github/workflows/master-release.yml
@@ -10,9 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow
-      - uses: olafurpg/setup-scala@v14
+      - uses: actions/setup-java@v4
         with:
-          java-version: adopt@1.8
+          distribution: adopt
+          java-version: 8
       - run: |
           sudo apt-get update && sudo apt-get -y install gnupg2
           mkdir ~/.gnupg && chmod 700 ~/.gnupg

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11]
+        java: ['8', '11']
         scala:
           - 2.12.18
           - 2.12.19
@@ -16,9 +16,10 @@ jobs:
           - 2.13.13
     steps:
       - uses: actions/checkout@v4
-      - uses: olafurpg/setup-scala@v14
+      - uses: actions/setup-java@v4
         with:
-          java-version: adopt@1.${{matrix.java}}
+          distribution: adopt
+          java-version: ${{matrix.java}}
       - uses: actions/cache@v4
         with:
           path: ~/.ivy2/cache
@@ -35,9 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: olafurpg/setup-scala@v14
+      - uses: actions/setup-java@v4
         with:
-          java-version: adopt@1.11
+          distribution: adopt
+          java-version: 11
       - uses: actions/cache@v4
         with:
           path: ~/.ivy2/cache


### PR DESCRIPTION
Setup-scala is not maintained anymore and uses Node.js 16. Node.js 16 actions are deprecated. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.