### PR TITLE
Add versionScheme early-semver to build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ crossTarget := {
   // workaround for https://github.com/sbt/sbt/issues/5097
   target.value / s"scala-${scalaVersion.value}"
 }
+versionScheme := Some("early-semver")
 
 // https://github.com/sksamuel/scapegoat/issues/298
 ThisBuild / useCoursier := false


### PR DESCRIPTION
So tooling can use it for eviction errors etc - https://www.scala-sbt.org/1.x/docs/Publishing.html