### PR TITLE
Fix false positive in VariableShadowing (#398)

### DIFF
--- a/src/main/scala-2/com/sksamuel/scapegoat/inspections/VariableShadowing.scala
+++ b/src/main/scala-2/com/sksamuel/scapegoat/inspections/VariableShadowing.scala
@@ -31,7 +31,9 @@ class VariableShadowing
             tree match {
               case Block(_, _) | ClassDef(_, _, _, Template(_, _, _)) | ModuleDef(_, _, Template(_, _, _)) |
                   Function(_, _) =>
-                enter(); continue(tree); exit()
+                enter()
+                continue(tree)
+                exit()
               case DefDef(_, name, _, vparamss, _, rhs) =>
                 enter()
                 // For case classes there's a synthetic constructor (not marked as <synthentic>) which takes
@@ -40,13 +42,13 @@ class VariableShadowing
                   vparamss.foreach(_.foreach(inspect))
                 inspect(rhs)
                 exit()
-              case ValDef(_, TermName(name), _, _) =>
+              case ValDef(_, TermName(name), _, _) if name != "_" =>
                 if (isDefined(name)) context.warn(tree.pos, self, tree.toString.take(200))
                 contexts.headOption.foreach(_.append(name.trim))
               case Match(_, cases) =>
                 cases.foreach {
-                  case CaseDef(Bind(name, _), _, _) =>
-                    if (isDefined(name.toString)) context.warn(tree.pos, self, tree.toString.take(200))
+                  case CaseDef(Bind(name, _), _, _) if isDefined(name.toString) =>
+                    context.warn(tree.pos, self, tree.toString.take(200))
                   case _ => // do nothing
                 }
                 continue(tree)

--- a/src/test/scala-2/com/sksamuel/scapegoat/inspections/VariableShadowingTest.scala
+++ b/src/test/scala-2/com/sksamuel/scapegoat/inspections/VariableShadowingTest.scala
@@ -127,14 +127,14 @@ class VariableShadowingTest extends InspectionTest {
 
       "when two sibling cases define the same local variable" in {
         val code = """class Test {
-                     |  val possibility: Option[Int] = Some(3) 
+                     |  val possibility: Option[Int] = Some(3)
                      |  possibility match {
-                     |    case Some(x) => 
-                     |      val y = x + 1    
+                     |    case Some(x) =>
+                     |      val y = x + 1
                      |      println(y)
                      |    case None =>
                      |      val y = 0
-                     |      println(y)     
+                     |      println(y)
                      |  }
                      |}""".stripMargin
 
@@ -225,7 +225,7 @@ class VariableShadowingTest extends InspectionTest {
         val code = """object Test {
                      |  for {
                      |    _ <- Right("something")
-                     |    _ <- Right("something")
+                     |    _ <- Right("something2")
                      |  } yield ()
                      |}""".stripMargin
         compileCodeSnippet(code)

--- a/src/test/scala-2/com/sksamuel/scapegoat/inspections/VariableShadowingTest.scala
+++ b/src/test/scala-2/com/sksamuel/scapegoat/inspections/VariableShadowingTest.scala
@@ -5,222 +5,206 @@ import com.sksamuel.scapegoat.{Inspection, InspectionTest}
 /** @author Stephen Samuel */
 class VariableShadowingTest extends InspectionTest {
 
-  override val inspections = Seq[Inspection](new VariableShadowing)
+  override val inspections: Seq[Inspection] = Seq(new VariableShadowing)
 
   "VariableShadowing" - {
     "should report warning" - {
       "when variable shadows in nested def" in {
-        val code =
-          """class Test {
-            |  def foo = {
-            |    val a = 1
-            |    def boo = {
-            |      val a = 2
-            |      println(a)
-            |    }
-            |  }
-            |} """.stripMargin
+        val code = """class Test {
+                     |  def foo = {
+                     |    val a = 1
+                     |    def boo = {
+                     |      val a = 2
+                     |      println(a)
+                     |    }
+                     |  }
+                     |}""".stripMargin
 
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 1
       }
+
       "when variable defined in def shadows field" in {
-        val code =
-          """class Test {
-            |  val a = 1
-            |  def foo = {
-            |    val a = 2
-            |    println(a)
-            |  }
-            |} """.stripMargin
+        val code = """class Test {
+                     |  val a = 1
+                     |  def foo = {
+                     |    val a = 2
+                     |    println(a)
+                     |  }
+                     |}""".stripMargin
 
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 1
       }
+
       "when variable defined as case bind shadows field" in {
-        val code =
-          """class Test {
-            |  val a = 1
-            |  def foo(b : Int) = b match {
-            |    case a => println(a)
-            |  }
-            |} """.stripMargin
+        val code = """class Test {
+                     |  val a = 1
+                     |  def foo(b : Int) = b match {
+                     |    case a => println(a)
+                     |  }
+                     |}""".stripMargin
 
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 1
       }
+
       "when variable defined in nested def in case shadows field" in {
-        val code =
-          """class Test {
-            |  val a = 1
-            |  def foo(b : Int) = b match {
-            |    case f =>
-            |     def boo() = {
-            |       val a = 2
-            |       println(a)
-            |     }
-            |  }
-            |} """.stripMargin
+        val code = """class Test {
+                     |  val a = 1
+                     |  def foo(b : Int) = b match {
+                     |    case f =>
+                     |      def boo() = {
+                     |        val a = 2
+                     |        println(a)
+                     |      }
+                     |  }
+                     |}""".stripMargin
 
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 1
       }
+
       "when variable defined in def shadows parameter" in {
-        val code =
-          """class Test {
-            |  def foo(a : Int) = {
-            |    val a = 1
-            |    println(a)
-            |  }
-            |} """.stripMargin
+        val code = """class Test {
+                     |  def foo(a : Int) = {
+                     |    val a = 1
+                     |    println(a)
+                     |  }
+                     |}""".stripMargin
 
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 1
       }
+
       "when variable defined in nested def shadows outer def parameter" in {
-        val code =
-          """class Test {
-            |  def foo(a : Int) = {
-            |    println(a)
-            |    def boo = {
-            |      val a = 2
-            |      println(a)
-            |    }
-            |  }
-            |} """.stripMargin
+        val code = """class Test {
+                     |  def foo(a : Int) = {
+                     |    println(a)
+                     |    def boo = {
+                     |      val a = 2
+                     |      println(a)
+                     |    }
+                     |  }
+                     |}""".stripMargin
 
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 1
       }
     }
+
     "should not report warning" - {
       "when sibling defs define same variable" in {
-        val code =
-          """class Test {
-            |  def foo = {
-            |    val a = 1
-            |    println(a)
-            |  }
-            |  def boo = {
-            |    val a = 2
-            |    println(a)
-            |  }
-            |} """.stripMargin
+        val code = """class Test {
+                     |  def foo = {
+                     |    val a = 1
+                     |    println(a)
+                     |  }
+                     |  def boo = {
+                     |    val a = 2
+                     |    println(a)
+                     |  }
+                     |}""".stripMargin
 
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
 
       "when two if branches define the same variable" in {
-        val code =
-          """class Test {
-            |  if (1 > 0) {
-            |    val something = 4
-            |    println(something+1)
-            |  } else {
-            |    val something = 2
-            |    println(something+2)
-            |  }
-            |}""".stripMargin
+        val code = """class Test {
+                     |  if (1 > 0) {
+                     |    val something = 4
+                     |    println(something+1)
+                     |  } else {
+                     |    val something = 2
+                     |    println(something+2)
+                     |  }
+                     |}""".stripMargin
 
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
 
       "when two sibling cases define the same local variable" in {
-        val code =
-          """class Test {
-            |  val possibility: Option[Int] = Some(3) 
-            |  possibility match {
-            |    case Some(x) => 
-            |      val y = x + 1    
-            |      println(y)
-            |    case None =>
-            |      val y = 0
-            |      println(y)     
-            |  }
-            |}""".stripMargin
+        val code = """class Test {
+                     |  val possibility: Option[Int] = Some(3) 
+                     |  possibility match {
+                     |    case Some(x) => 
+                     |      val y = x + 1    
+                     |      println(y)
+                     |    case None =>
+                     |      val y = 0
+                     |      println(y)     
+                     |  }
+                     |}""".stripMargin
 
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
 
       "when visiting a match case, especially not visit it twice" in {
-        val code =
-          """class Test {
-            |  val possibility: Option[Int] = Some(3)
-            |  possibility match {
-            |    case Some(x) =>
-            |      val y = x + 1
-            |      println(y)
-            |    case None => println("None")
-            |  }
-            |}""".stripMargin
+        val code = """class Test {
+                     |  val possibility: Option[Int] = Some(3)
+                     |  possibility match {
+                     |    case Some(x) =>
+                     |      val y = x + 1
+                     |      println(y)
+                     |    case None => println("None")
+                     |  }
+                     |}""".stripMargin
 
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
 
       "when sibling case classes use the same argument name" in {
-        val code =
-          """
-            |final case class A(value: String)
-            |final case class B(value: String)
-            |final case class C(value: Int)
-            |""".stripMargin
+        val code = """final case class A(value: String)
+                     |final case class B(value: String)
+                     |final case class C(value: Int)
+                     |""".stripMargin
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
 
       "when the same variable is used in two sibling for loops (#342)" in {
-        val code =
-          """
-            |object Test {
-            |  for (i <- 1 to 10) println(i.toString)
-            |  for (i <- 1 to 10) println(i.toString)
-            |}
-            |""".stripMargin
+        val code = """object Test {
+                     |  for (i <- 1 to 10) println(i.toString)
+                     |  for (i <- 1 to 10) println(i.toString)
+                     |}""".stripMargin
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
 
       "when using for-comprehension (#343)" in {
-        val code =
-          """
-            |object Test {
-            |  for {
-            |    c <- "Hello, world!"
-            |    if c != ','
-            |  } println(c)
-            |}
-            |""".stripMargin
+        val code = """object Test {
+                     |  for {
+                     |    c <- "Hello, world!"
+                     |    if c != ','
+                     |  } println(c)
+                     |}""".stripMargin
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
+
       "when using Builder-pattern method chaining (#398)" in {
-        val code =
-          """
-            |object Test {
-            |
-            |  def f(x: Int): String = x.toString
-            |  def g(y: String): Int = y.toInt
-            |
-            |  val a = Seq(1, 2, 3)
-            |  System.out.println(
-            |   a
-            |    .map(s => f(s))
-            |    .map(s => g(s))
-            |  )
-            |}
-            |""".stripMargin
+        val code = """object Test {
+                     |  def f(x: Int): String = x.toString
+                     |  def g(y: String): Int = y.toInt
+                     |
+                     |  val a = Seq(1, 2, 3)
+                     |  System.out.println(
+                     |    a
+                     |     .map(s => f(s))
+                     |     .map(s => g(s))
+                     |  )
+                     |}""".stripMargin
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
 
       "when passing function as an argument (#419)" in {
         val code =
-          """
-            |class TestVariableShadowing {
+          """class TestVariableShadowing {
             |  private def testCallbackFunction1(shadowedArg: Long): Boolean = shadowedArg > 10
             |  private def testCallbackFunction2(arg: Long): Boolean = arg < 10
             |
@@ -232,12 +216,21 @@ class VariableShadowingTest extends InspectionTest {
             |      case l2: Double => testCaller(l2.toLong, testCallbackFunction2)
             |      case l3         => false
             |    }
-            |}
-            |""".stripMargin
+            |}""".stripMargin
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
 
+      "when using underscores as variable name" in {
+        val code = """object Test {
+                     |  for {
+                     |    _ <- Right("something")
+                     |    _ <- Right("something")
+                     |  } yield ()
+                     |}""".stripMargin
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #398.

The test only failed on Scala 2.12. Fixed by ignoring `_` variable names.