### PR TITLE
Add new inspection: abstract trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ An overview list is given, followed by a more detailed description of each inspe
 
 | Name                                  | Brief Description                                                                                                                                            | Default Level | Scala 2 | Scala 3 |
 |---------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|---------|---------|
+| AbstractTrait                         | Check if trait is abstract                                                                                                                                   | Info          | Yes     | No      |
 | ArrayEquals                           | Checks for comparison of arrays using `==` which will always return false                                                                                    | Info          | Yes     | No      |
 | ArraysInFormat                        | Checks for arrays passed to String.format                                                                                                                    | Error         | Yes     | No      |
 | ArraysToString                        | Checks for explicit toString calls on arrays                                                                                                                 | Warning       | Yes     | No      |
@@ -283,7 +284,6 @@ An overview list is given, followed by a more detailed description of each inspe
 | VariableShadowing                     | Checks for multiple uses of the variable name in nested scopes                                                                                               | Warning       | Yes     | No      |
 | WhileTrue                             | Checks for code that uses a `while(true)` or `do { } while(true)` block.                                                                                     | Warning       | Yes     | No      |
 | ZeroNumerator                         | Checks for dividing by 0 by a number, eg `0 / x` which will always return `0`                                                                                | Warning       | Yes     | No      |
-| AbstractTrait                         | Check if trait is abstract                                                                                                                                   | Info          | Yes     | No      |
 
 ##### Arrays to string
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ An overview list is given, followed by a more detailed description of each inspe
 | VariableShadowing                     | Checks for multiple uses of the variable name in nested scopes                                                                                               | Warning       | Yes     | No      |
 | WhileTrue                             | Checks for code that uses a `while(true)` or `do { } while(true)` block.                                                                                     | Warning       | Yes     | No      |
 | ZeroNumerator                         | Checks for dividing by 0 by a number, eg `0 / x` which will always return `0`                                                                                | Warning       | Yes     | No      |
+| AbstractTrait                         | Check if trat is abstract                                                                                                                                    | Info          | Yes     | No      | 
 
 ##### Arrays to string
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ To suppress warnings globally for the project, use `disabledInspections` or `ove
 
 ### Inspections
 
-There are currently 121 inspections for Scala 2, and 1 for Scala 3.
+There are currently 122 inspections for Scala 2, and 1 for Scala 3.
 An overview list is given, followed by a more detailed description of each inspection after the list (todo: finish rest of detailed descriptions)
 
 | Name                                  | Brief Description                                                                                                                                            | Default Level | Scala 2 | Scala 3 |
@@ -283,7 +283,7 @@ An overview list is given, followed by a more detailed description of each inspe
 | VariableShadowing                     | Checks for multiple uses of the variable name in nested scopes                                                                                               | Warning       | Yes     | No      |
 | WhileTrue                             | Checks for code that uses a `while(true)` or `do { } while(true)` block.                                                                                     | Warning       | Yes     | No      |
 | ZeroNumerator                         | Checks for dividing by 0 by a number, eg `0 / x` which will always return `0`                                                                                | Warning       | Yes     | No      |
-| AbstractTrait                         | Check if trat is abstract                                                                                                                                    | Info          | Yes     | No      | 
+| AbstractTrait                         | Check if trait is abstract                                                                                                                                   | Info          | Yes     | No      |
 
 ##### Arrays to string
 

--- a/src/main/scala-2/com/sksamuel/scapegoat/Inspections.scala
+++ b/src/main/scala-2/com/sksamuel/scapegoat/Inspections.scala
@@ -16,6 +16,7 @@ import com.sksamuel.scapegoat.inspections.option._
 import com.sksamuel.scapegoat.inspections.string._
 import com.sksamuel.scapegoat.inspections.style._
 import com.sksamuel.scapegoat.inspections.unneccesary._
+import com.sksamuel.scapegoat.inspections.traits._
 import com.sksamuel.scapegoat.inspections.unsafe._
 
 /**
@@ -146,6 +147,7 @@ object Inspections extends App {
       new VarClosure,
       new VarCouldBeVal,
       new WhileTrue,
-      new ZeroNumerator
+      new ZeroNumerator,
+      new AbstractTrait
     )
 }

--- a/src/main/scala-2/com/sksamuel/scapegoat/inspections/traits/AbstractTrait.scala
+++ b/src/main/scala-2/com/sksamuel/scapegoat/inspections/traits/AbstractTrait.scala
@@ -1,0 +1,35 @@
+package com.sksamuel.scapegoat.inspections.traits
+
+import com.sksamuel.scapegoat.*
+
+class AbstractTrait
+  extends Inspection(
+    text = "Use of abstract trait",
+    defaultLevel = Levels.Info,
+    description = "Traits are automatically abstract.",
+    explanation = "The abstract modifier is used in class definitions. It is redundant for traits, and mandatory for all other classes which have incomplete members."
+  ){
+
+  override def inspector(ctx: InspectionContext): Inspector = {
+    new Inspector(ctx) {
+      override def postTyperTraverser: context.Traverser =
+        new context.Traverser {
+
+          import context.global._
+
+          def isAbstractTrait(positions: Map[Long, Position]): Boolean = {
+            positions.contains(Flag.TRAIT) && positions.contains(Flag.ABSTRACT)
+          }
+
+          override def inspect(tree: Tree): Unit = {
+            tree match {
+              // I use positions, because all traits are abstract by default
+              case ClassDef(mods, _, _, _) if isAbstractTrait(mods.positions) =>
+                context.warn(tree.pos, self, tree.toString.take(500))
+              case _ => continue(tree)
+            }
+          }
+        }
+    }
+  }
+}

--- a/src/main/scala-2/com/sksamuel/scapegoat/inspections/traits/AbstractTrait.scala
+++ b/src/main/scala-2/com/sksamuel/scapegoat/inspections/traits/AbstractTrait.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.scapegoat.inspections.traits
 
-import com.sksamuel.scapegoat.*
+import com.sksamuel.scapegoat._
 
 class AbstractTrait
   extends Inspection(

--- a/src/test/scala-2/com/sksamuel/scapegoat/inspections/traits/AbstractTraitTest.scala
+++ b/src/test/scala-2/com/sksamuel/scapegoat/inspections/traits/AbstractTraitTest.scala
@@ -1,0 +1,39 @@
+package com.sksamuel.scapegoat.inspections.traits
+
+import com.sksamuel.scapegoat.{Inspection, InspectionTest}
+
+class AbstractTraitTest extends InspectionTest {
+
+  override val inspections = Seq[Inspection](new AbstractTrait)
+
+  "abstract trait use" - {
+    "should report warning" in {
+      val code = "abstract trait Test { val x: Int = 1 }"
+
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 1
+    }
+
+    "should not report warning on sealed" in {
+      val code = "sealed trait Test { val x: Int = 1 }"
+
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 0
+    }
+
+    "should not report warning on trait without modifiers" in {
+      val code = "trait Test1 { val x: Int = 1 }"
+
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 0
+    }
+
+    "should not report on private trait" in {
+      val code = "private trait Test1 { val x: Int = 1 }"
+
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 0
+    }
+  }
+
+}


### PR DESCRIPTION
Hello,
I implemented new inspection: check if trait is abstract (first from this list: https://github.com/scapegoat-scala/scapegoat/issues/302)