### PR TITLE
ubuntu2204-for-release

### DIFF
--- a/.github/workflows/master-release.yml
+++ b/.github/workflows/master-release.yml
@@ -5,7 +5,7 @@ on:
     tags: ["*"]
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'scapegoat-scala/scapegoat'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
**What**:
Switching from `ubuntu-latest` to `ubuntu-2204` for the release Github Action workflow.

**Why**:
In an attempt to address failures - #923.