### PR TITLE
Use ubuntu-22.04

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,7 +4,7 @@ on:
 jobs:
   test:
     name: Test using JDK ${{matrix.java}} and Scala ${{matrix.scala}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -35,7 +35,7 @@ jobs:
       - run: sbt ++${{matrix.scala}}! test
   additional-checks:
     name: Run additional checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4


### PR DESCRIPTION
**What**:
Similar to #924.
Switching from `ubuntu-latest` to `ubuntu-2204` for the CI.

**Why**:
- In an attempt to address failures - #923.
- TBH, I didn't investigate what would it take to run in the (new) `ubuntu-latest`. Maybe it's just some tiny thing...
