### PR TITLE
Support for Scala 3.6.3 and 3.3.5

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,8 +14,8 @@ jobs:
           - 2.12.20
           - 2.13.15
           - 2.13.16
-          - 3.3.4
-          - 3.6.2
+          - 3.3.5
+          - 3.6.3
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,8 @@ developers := List(
   )
 )
 
-scalaVersion := "3.6.2"
-crossScalaVersions := Seq("2.12.19", "2.12.20", "2.13.15", "2.13.16", "3.3.4", "3.6.2")
+scalaVersion := "3.6.3"
+crossScalaVersions := Seq("2.12.19", "2.12.20", "2.13.15", "2.13.16", "3.3.5", "3.6.3")
 autoScalaLibrary := false
 crossVersion := CrossVersion.full
 crossTarget := {


### PR DESCRIPTION
Fixes #938.

Closes #926.
Closes #930.

According to previous examples project only keeps latest and latest LTS for Scala 3 - bumping both with this changeset.