### PR TITLE
feat: Support Suppression of warnings on Scala 3

### DIFF
--- a/src/main/scala-3/com/sksamuel/scapegoat/Inspection.scala
+++ b/src/main/scala-3/com/sksamuel/scapegoat/Inspection.scala
@@ -11,7 +11,7 @@ abstract class Inspection(
   val explanation: String
 ) extends InspectionBase {
 
-  val self: Inspection = this
+  implicit val self: Inspection = this
 
   def inspect(feedback: Feedback[SourcePosition], tree: tpd.Tree)(using Context): Unit
 

--- a/src/main/scala-3/com/sksamuel/scapegoat/InspectionTraverser.scala
+++ b/src/main/scala-3/com/sksamuel/scapegoat/InspectionTraverser.scala
@@ -1,10 +1,41 @@
 package com.sksamuel.scapegoat
 
+import dotty.tools.dotc.ast.Trees
+import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.ast.tpd.*
+import dotty.tools.dotc.core.Constants
 import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Names
+import dotty.tools.dotc.core.Symbols
+import dotty.tools.dotc.core.Symbols.requiredClass
 import dotty.tools.dotc.util.NoSource
 
 abstract class InspectionTraverser extends TreeTraverser {
+
+  override protected def traverseChildren(tree: tpd.Tree)(using Context): Unit = {
+    if (!isSuppressed(tree)) {
+      super.traverseChildren(tree)
+    }
+  }
+
+  private def isSuppressed(t: tpd.Tree)(using Context): Boolean = {
+    t.symbol.getAnnotation(requiredClass("java.lang.SuppressWarnings")).flatMap(_.argument(0)) match {
+      case Some(
+            NamedArg(
+              _,
+              Apply(
+                Apply(TypeApply(Select(Ident(name), _), _), List(Typed(SeqLiteral(args, _), _))),
+                _
+              )
+            )
+          ) if name.toTermName == Names.termName("Array") =>
+        args.collectFirst {
+          case Literal(value) if value.tag == Constants.StringTag =>
+            value.stringValue == "all"
+        }.isDefined
+      case _ => false
+    }
+  }
 
   extension (tree: Tree)(using Context)
     def asSnippet: Option[String] = tree.source match

--- a/src/test/scala-3/com/sksamuel/scapegoat/InspectionTraverserTest.scala
+++ b/src/test/scala-3/com/sksamuel/scapegoat/InspectionTraverserTest.scala
@@ -1,0 +1,42 @@
+package com.sksamuel.scapegoat
+
+import com.sksamuel.scapegoat.inspections.option.OptionGet
+
+class InspectionTraverserTest extends InspectionTest(classOf[OptionGet]) {
+  "InspectionTraverser" - {
+    "should ignore inspection based on SuppressWarnings on class" in {
+      val code = """
+      @SuppressWarnings(Array("all"))
+      class Test {
+        val o = Option("sammy")
+        o.get
+      }""".stripMargin
+
+      val feedback = runner.compileCodeSnippet(code)
+      feedback.errors.assertable shouldEqual Seq.empty
+    }
+
+    "should ignore inspection based on SuppressWarnings on method" in {
+      val code = """
+      class Test {
+        @SuppressWarnings(Array("all"))
+        def func(): String = {
+          // ignored violation
+          val o = Option("sammy")
+          o.get
+        }
+
+        // violation
+        val o2 = Option("sammy")
+        o2.get
+
+        func()
+      }""".stripMargin
+
+      val feedback = runner.compileCodeSnippet(code)
+      feedback.errors.assertable shouldEqual Seq(
+        warning(11, Levels.Error, Some("o2.get"))
+      )
+    }
+  }
+}

--- a/src/test/scala-3/com/sksamuel/scapegoat/InspectionTraverserTest.scala
+++ b/src/test/scala-3/com/sksamuel/scapegoat/InspectionTraverserTest.scala
@@ -4,7 +4,7 @@ import com.sksamuel.scapegoat.inspections.option.OptionGet
 
 class InspectionTraverserTest extends InspectionTest(classOf[OptionGet]) {
   "InspectionTraverser" - {
-    "should ignore inspection based on SuppressWarnings on class" in {
+    "should ignore all inspection based on SuppressWarnings on class" in {
       val code = """
       @SuppressWarnings(Array("all"))
       class Test {
@@ -16,7 +16,33 @@ class InspectionTraverserTest extends InspectionTest(classOf[OptionGet]) {
       feedback.errors.assertable shouldEqual Seq.empty
     }
 
-    "should ignore inspection based on SuppressWarnings on method" in {
+    "should ignore specific inspection based on SuppressWarnings on class" in {
+      val code = """
+      @SuppressWarnings(Array("OptionGet"))
+      class Test {
+        val o = Option("sammy")
+        o.get
+      }""".stripMargin
+
+      val feedback = runner.compileCodeSnippet(code)
+      feedback.errors.assertable shouldEqual Seq.empty
+    }
+
+    "should ignore specific inspection based on SuppressWarnings on class (Different warning)" in {
+      val code = """
+      @SuppressWarnings(Array("AvoidRequire"))
+      class Test {
+        val o = Option("sammy")
+        o.get
+      }""".stripMargin
+
+      val feedback = runner.compileCodeSnippet(code)
+      feedback.errors.assertable shouldEqual Seq(
+        warning(4, Levels.Error, Some("o.get"))
+      )
+    }
+
+    "should ignore all inspection based on SuppressWarnings on method" in {
       val code = """
       class Test {
         @SuppressWarnings(Array("all"))


### PR DESCRIPTION
> A test for our Scala 3 implementation for @SuppressWarnings.

Start of support for fine grained silencing through skipping any tree that is annotated with SuppressWarnings to aid in #944 .

Todo:
- [x] Extracting the constants out of the array is very unwieldy, surely this can be done nicer -> not a lot better it seems
- [x] Inspection specific silencing